### PR TITLE
fix: apply so that it only runs when a PR is merged

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -145,7 +145,7 @@ runs:
         add_github_comment:  ${{ inputs.add_github_comment }}
 
     - name: tofu apply
-      if: github.event.pull_request.merged == true
+      if: github.ref_name == 'main' && github.event.pull_request.merged == true
       uses: dflook/tofu-apply@d616dca95ca793b33640e7488312b576fa5da86e # v1.43.0
       with:
         path: ${{ inputs.path }}

--- a/action.yml
+++ b/action.yml
@@ -145,7 +145,7 @@ runs:
         add_github_comment:  ${{ inputs.add_github_comment }}
 
     - name: tofu apply
-      if: github.ref_name == 'main'
+      if: github.ref_name == 'main' && github.event.pull_request.merged == true
       uses: dflook/tofu-apply@d616dca95ca793b33640e7488312b576fa5da86e # v1.43.0
       with:
         path: ${{ inputs.path }}

--- a/action.yml
+++ b/action.yml
@@ -145,7 +145,7 @@ runs:
         add_github_comment:  ${{ inputs.add_github_comment }}
 
     - name: tofu apply
-      if: github.ref_name == 'main' && github.event.pull_request.merged == true
+      if: github.event.pull_request.merged == true
       uses: dflook/tofu-apply@d616dca95ca793b33640e7488312b576fa5da86e # v1.43.0
       with:
         path: ${{ inputs.path }}


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Updated the `tofu apply` action in `action.yml` to run only when a pull request is merged into the `main` branch.
- Ensured the action is not triggered on other events or branches.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>action.yml</strong><dd><code>Restrict `tofu apply` action to run only on PR merge to main</code></dd></summary>
<hr>

action.yml
<li>Modified the condition for running the <code>tofu apply</code> step.<br> <li> Added a check to ensure the action only runs when a PR is merged into <br>the <code>main</code> branch.<br>


</details>
    

  </td>
  <td><a href="https://github.com/GlueOps/github-actions-opentofu-continuous-delivery/pull/24/files#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

