### PR TITLE
feat: publish full plan to summary/artifact and remove Slack notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-This action is an opinionated wrapper around the work of Daniel Flook: https://github.com/dflook/terraform-github-actions and leverages https://github.com/trstringer/manual-approval as the approval step before applying. Slack notifications are also enabled by default.
+This action is an opinionated wrapper around the work of Daniel Flook: https://github.com/dflook/terraform-github-actions and leverages https://github.com/trstringer/manual-approval as the approval step before applying.
 
 ## Usage
 
@@ -14,7 +14,6 @@ Example:
 env:
   TERRAFORM_ACTIONS_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   OPENTOFU_VERSION: "1.6.2"
-  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   # more provider environment variables can be set here
 
 
@@ -40,7 +39,6 @@ jobs:
       - name: OpenTofu CD              
         uses: GlueOps/github-actions-opentofu-continuous-delivery@v0.0.9
         with:
-          enable_slack_notification_for_approval: "true"
           backend_config: |
             access_key=${{ vars.TF_S3_BACKEND_AWS_ACCESS_KEY }}
             secret_key=${{ secrets.TF_S3_BACKEND_AWS_SECRET_ACCESS_KEY }}
@@ -60,6 +58,14 @@ jobs:
 ## Job Configuration
 - **Concurrency**: Limits concurrent runs to prevent overlapping runs.
 
+## Viewing the plan
+
+The plan is posted as a PR/commit comment via `add_github_comment`. GitHub comments are capped at ~64 KB, so large plans get truncated there. To make the full plan available regardless of size, every run also:
+
+- Renders the full, human-readable plan to the **job summary** page of the run (browser-viewable, searchable, no download).
+- Uploads the full plan as a downloadable **artifact** named `tofu-plan` (no practical size limit; fallback for very large plans).
+
+When an apply on `main` requires manual approval, the approval issue created by [manual-approval](https://github.com/trstringer/manual-approval) links directly to both the job summary and the artifact, so you can review the complete plan before approving — no need to cancel and re-run.
 
 ## Inputs
 
@@ -78,7 +84,8 @@ jobs:
 | `destroy` | Create and apply a plan to destroy all resources | ❌ | `false` |
 | `backend_type` | The backend plugin name | ✅ | _None_ |
 | `add_github_comment` | Add the plan to a GitHub PR | ❌ | `true` |
-| `enable_slack_notification_for_approval` | Enable or Disable Slack notifications | ❌ | `true` |
+| `enable_slack_notification_for_approval` | **Deprecated and ignored.** Slack notifications have been removed; retained only for backward compatibility. | ❌ | `true` |
+| `ENABLE_DANGEROUS_AUTO_APPLY_MODE` | If enabled, any changes including Destroy, Apply, and Replace will be automatically approved (skips the manual approval step). | ❌ | `false` |
 
 ## Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -57,7 +57,7 @@ inputs:
     required: false
     default: "true"
   enable_slack_notification_for_approval:
-    description: Enable or Disable slack notifications
+    description: "DEPRECATED and ignored. Slack notifications have been removed entirely. This input is retained only to avoid breaking existing workflows that still set it."
     required: false
     default: "true"
   ENABLE_DANGEROUS_AUTO_APPLY_MODE:
@@ -93,6 +93,14 @@ runs:
   steps:
     - name: Checkout
       uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+    # Slack notifications were removed entirely. The `enable_slack_notification_for_approval`
+    # input is kept as a no-op so existing workflows that still set it don't break.
+    - name: Slack notifications removed (deprecation notice)
+      if: inputs.enable_slack_notification_for_approval != ''
+      shell: bash
+      run: |
+        echo "::warning title=Slack notifications removed::Slack notifications have been removed from this action. The 'enable_slack_notification_for_approval' input is now ignored and retained only for backward compatibility. Please remove it from your workflow."
 
     - name: tofu fmt
       uses: dflook/tofu-fmt-check@1ae8a83029b8ad8e6c6a12834e0d3d9cd0e34d5f # v2.2.3
@@ -143,29 +151,32 @@ runs:
         destroy: ${{ inputs.destroy }}
         add_github_comment:  ${{ inputs.add_github_comment }}
 
+    # Publishes the full, human-readable plan to the run's job summary page.
+    # GitHub PR/issue/commit comments are capped at 65,536 characters, so large
+    # plans get truncated in the PR comment and the approval issue. The job
+    # summary has a ~1 MiB limit and renders in the browser, so approvers can
+    # read the full plan without downloading anything or re-running the workflow.
+    - name: Publish full plan to job summary
+      if: steps.plan.outputs.text_plan_path != ''
+      shell: bash
+      run: |
+        {
+          echo '## OpenTofu Plan'
+          echo '```'
+          cat "${{ steps.plan.outputs.text_plan_path }}"
+          echo '```'
+        } >> "$GITHUB_STEP_SUMMARY"
 
-    
-    - name: Notify in Slack about Approving/Denying to continue workflow
-      if: github.ref_name == 'main' && steps.plan.outputs.changes == 'true' && inputs.enable_slack_notification_for_approval == 'true' && github.event_name != 'pull_request' && inputs.ENABLE_DANGEROUS_AUTO_APPLY_MODE == 'false' 
-      uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
+    # Uploads the full text plan as a downloadable artifact. The job summary
+    # above covers the common case, but artifacts have no practical size limit
+    # and never truncate, so this is the fallback for very large plans (>1 MiB).
+    - name: Upload full plan as artifact
+      id: upload_plan
+      if: steps.plan.outputs.text_plan_path != ''
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
-        webhook-type: webhook-trigger
-        payload: |
-           {
-                "attachments": [
-                    {
-                        "color": "#FFA500",
-                        "author_name": ":link: OpenTofu - ${{ github.event.repository.name }} - Job Details",
-                        "author_link": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}",
-                        "title": "https://github.com/${{ github.repository }}",
-                        "title_link": "https://github.com/${{ github.repository }}",
-                        "text": ":raising_hand: Approval Required: https://github.com/${{ github.repository }}/issues"
-                    }
-                ]
-            }
-      env:
-        SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
-
+        name: tofu-plan
+        path: ${{ steps.plan.outputs.text_plan_path }}
 
     ## IMPORTANT
     ## DO NOT REMOVE THIS MANUAL APPROVAL STEP UNLESS YOU WANT AUTO APPLY WITHOUT ANY APPROVALS.
@@ -177,7 +188,11 @@ runs:
         approvers: ${{ github.actor }}
         minimum-approvals: 1
         issue-title: "Approve or Deny tofu apply"
-        issue-body: "Approve or Deny tofu apply"
+        issue-body: |
+          Approve or Deny tofu apply.
+
+          - Full plan (rendered in browser, job summary): https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          - Full plan (downloadable artifact): ${{ steps.upload_plan.outputs.artifact-url }}
         exclude-workflow-initiator-as-approver: false
 
     - name: tofu apply
@@ -196,46 +211,3 @@ runs:
         target: ${{ inputs.target }}
         replace: ${{ inputs.replace }}
         destroy: ${{ inputs.destroy }}
-
-    - name: Notify on Success
-      if: always() && success() && inputs.enable_slack_notification_for_approval == 'true'
-      uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
-      with:
-        webhook-type: webhook-trigger
-        payload: |
-           {
-                "attachments": [
-                    {
-                        "color": "#36a64f",
-                        "author_name": ":link: OpenTofu - ${{ github.event.repository.name }} - Job Details",
-                        "author_link": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}",
-                        "title": "https://github.com/${{ github.repository }}",
-                        "title_link": "https://github.com/${{ github.repository }}",
-                        "text": ":large_green_circle: SUCCESS :large_green_circle:"
-                    }
-                ]
-            }
-      env:
-        SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
-
-
-    - name: Notify on Failure
-      if: always() && failure() && inputs.enable_slack_notification_for_approval == 'true'
-      uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
-      with:
-        webhook-type: webhook-trigger
-        payload: |
-           {
-                "attachments": [
-                    {
-                        "color": "#FF0000",
-                        "author_name": ":link: OpenTofu - ${{ github.event.repository.name }} - Job Details",
-                        "author_link": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}",
-                        "title": "https://github.com/${{ github.repository }}",
-                        "title_link": "https://github.com/${{ github.repository }}",
-                        "text": ":rotating_light: FAILURE :rotating_light:"
-                    }
-                ]
-            }
-      env:
-        SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK


### PR DESCRIPTION
## What & why

When a tofu plan is too large for a GitHub comment (~64 KB cap), the plan gets truncated and there was no easy way to review the full plan — especially at the manual-approval gate — without cancelling and re-running. This PR makes the full plan always accessible, and removes Slack notifications.

## Plan visibility

- **Job summary**: the full human-readable plan is rendered to the run's job summary page (browser-viewable, searchable, no download).
- **Artifact**: the full plan is uploaded as a downloadable artifact named `tofu-plan` (no practical size limit; fallback for very large plans).
- **Approval links**: the `manual-approval` issue body now links directly to both the job summary and the artifact, so approvers can review the complete plan before approving — no cancel/re-run needed.

Both are produced *before* the approval gate, so they're available the moment the approval is requested.

## Slack removal

- Removed all Slack notification steps and the `slackapi/slack-github-action` usage.
- `enable_slack_notification_for_approval` is **kept as a deprecated no-op** so existing workflows that set it don't break; the action now logs a `::warning::` deprecation notice when it's present.

## Docs

- Added a "Viewing the plan" section.
- Documented the previously-undocumented `ENABLE_DANGEROUS_AUTO_APPLY_MODE` input.
- Marked `enable_slack_notification_for_approval` as deprecated/ignored.

## Notes

- This is **not** a breaking change (deprecated input retained).
- Renovate PR #124 (bumps the now-removed Slack action) is obsolete and can be closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)