### PR TITLE
feat: replace dflook PR comment with sticky links-only comment

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -1,0 +1,78 @@
+name: Integration Test
+
+# Runs the action against a throwaway local-backend fixture (test/) so changes
+# are exercised early. The plan/summary/artifact/comment path runs on every PR
+# commit; the apply path only runs on push to main (the action gates apply on
+# main), with auto-apply enabled so it never blocks on the approval issue.
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  push:
+    branches: [main]
+
+# Each ref runs in isolation; superseded commits are cancelled to save minutes.
+concurrency:
+  group: integration-test-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+env:
+  OPENTOFU_VERSION: "1.8.5"
+  TERRAFORM_ACTIONS_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    steps:
+      # Required so the local action (uses: ./) is available to the runner.
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - name: Run action under test
+        id: tofu
+        uses: ./
+        with:
+          path: test
+          backend_type: local
+          add_github_comment: "true"
+          # Auto-apply so the apply path on main is not blocked by the approval
+          # issue. On PRs the action does not apply (ref is not main) regardless.
+          ENABLE_DANGEROUS_AUTO_APPLY_MODE: "true"
+
+      - name: Assert plan detected a change
+        shell: bash
+        run: |
+          echo "changes=${{ steps.tofu.outputs.changes }} to_add=${{ steps.tofu.outputs.to_add }}"
+          test "${{ steps.tofu.outputs.changes }}" = "true"
+          test "${{ steps.tofu.outputs.to_add }}" = "1"
+
+      - name: Assert sticky plan comment was posted
+        if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          pr='${{ github.event.pull_request.number }}'
+          gh api "repos/${{ github.repository }}/issues/${pr}/comments" --jq '.[].body' \
+            | grep -q 'glueops-opentofu-plan' \
+            || { echo "::error::Expected sticky plan comment (marker) not found on PR #${pr}"; exit 1; }
+
+  verify-artifact:
+    needs: smoke
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download plan artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: tofu-plan
+          path: plan
+
+      - name: Assert artifact contains the plan
+        shell: bash
+        run: |
+          ls -la plan
+          grep -rq 'null_resource' plan \
+            || { echo "::error::tofu-plan artifact did not contain the expected plan content"; exit 1; }

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Download plan artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: tofu-plan
+          name: tofu-plan.txt
           path: plan
 
       - name: Assert artifact contains the plan

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -1,9 +1,13 @@
 name: Integration Test
 
 # Runs the action against a throwaway local-backend fixture (test/) so changes
-# are exercised early. The plan/summary/artifact/comment path runs on every PR
-# commit; the apply path only runs on push to main (the action gates apply on
-# main), with auto-apply enabled so it never blocks on the approval issue.
+# are exercised early. The plan/artifact/comment path runs on every PR commit;
+# the apply path only runs on push to main (the action gates apply on main),
+# with auto-apply enabled so it never blocks on the approval issue.
+#
+# NOTE: the manual-approval path (issue-body-file-path) is intentionally NOT
+# covered — auto-apply skips the approval gate, and exercising it would block on
+# a human. That path is verified by review, not CI.
 on:
   pull_request:
     types: [opened, synchronize, reopened]
@@ -55,16 +59,20 @@ jobs:
 
       # Only same-repo PRs get a writable token; fork PRs get a read-only token,
       # so the action intentionally skips the comment (no comment to assert).
-      - name: Assert sticky plan comment was posted
+      - name: Assert sticky plan comment was posted (with link + inlined plan)
         if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         env:
           GH_TOKEN: ${{ github.token }}
         shell: bash
         run: |
           pr='${{ github.event.pull_request.number }}'
-          gh api "repos/${{ github.repository }}/issues/${pr}/comments" --jq '.[].body' \
-            | grep -q 'glueops-opentofu-plan' \
-            || { echo "::error::Expected sticky plan comment (marker) not found on PR #${pr}"; exit 1; }
+          body="$(gh api "repos/${{ github.repository }}/issues/${pr}/comments" --jq '.[] | select(.body | contains("glueops-opentofu-plan")) | .body')"
+          [ -n "$body" ] || { echo "::error::sticky plan comment (marker) not found on PR #${pr}"; exit 1; }
+          # Always-present artifact download link.
+          printf '%s' "$body" | grep -q 'tofu-plan.txt' || { echo "::error::comment missing the artifact download link"; exit 1; }
+          # Small fixture: the plan must be inlined (collapsible block + content).
+          printf '%s' "$body" | grep -q '<details>' || { echo "::error::comment did not inline the plan (<details> missing)"; exit 1; }
+          printf '%s' "$body" | grep -q 'null_resource' || { echo "::error::comment did not contain the inlined plan content"; exit 1; }
 
   verify-artifact:
     needs: smoke

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -19,9 +19,13 @@ permissions:
   contents: read
   pull-requests: write
 
+# No GITHUB_TOKEN is exported here on purpose: this workflow runs on
+# pull_request (incl. forks) and executes the PR's own test/main.tf via
+# `tofu plan`. Exposing a repo token to that untrusted code would be a leak,
+# and the local-backend null fixture needs no token. The action's own steps
+# that need a token use github.token internally.
 env:
   OPENTOFU_VERSION: "1.8.5"
-  TERRAFORM_ACTIONS_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
   smoke:
@@ -49,8 +53,10 @@ jobs:
           test "${{ steps.tofu.outputs.changes }}" = "true"
           test "${{ steps.tofu.outputs.to_add }}" = "1"
 
+      # Only same-repo PRs get a writable token; fork PRs get a read-only token,
+      # so the action intentionally skips the comment (no comment to assert).
       - name: Assert sticky plan comment was posted
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         env:
           GH_TOKEN: ${{ github.token }}
         shell: bash

--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ on:
 jobs:
   terraform-action:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read        # checkout
+      issues: write         # manual approval gate on main
+      pull-requests: write  # sticky plan comment on PRs (add_github_comment)
     concurrency:
       group: limit-concurrency-do-not-remove-this
       cancel-in-progress: false
@@ -118,8 +122,8 @@ Beyond `contents: read` for checkout, the job summary and the `tofu-plan` artifa
 | `to_change` | The number of resources that would be changed by this plan |
 | `to_destroy` | The number of resources that would be destroyed by this plan |
 | `plan_path` | Path to the file containing the generated plan in an opaque binary format |
-| `text_plan_path` | Path to the file containing the generated plan in human-readable format |
-| `json_plan_path` | Path to the file containing the generated plan in JSON format |
+| `text_plan_path` | Path to the file containing the generated plan in human-readable format. Not set if the backend is `remote` and `auto_approve` is `true` |
+| `json_plan_path` | Path to the file containing the generated plan in JSON format. Not set if the backend is `remote` |
 | `run_id` | The remote run ID if using `remote` or `cloud` backend in remote execution mode |
 
 ## Secrets and Environment Variables

--- a/README.md
+++ b/README.md
@@ -60,12 +60,14 @@ jobs:
 
 ## Viewing the plan
 
-GitHub comments are capped at ~64 KB, so posting the plan inline truncates large plans. Instead, the full plan is always made available without that limit, and every surface just **links** to it consistently:
+GitHub comments are capped at ~64 KB, so posting the plan inline truncates large plans. Instead, the full plan is made available without that limit, and every surface just **links** to it consistently:
 
 - The full, human-readable plan is rendered to the run's **job summary** page (browser-viewable, searchable, no download). The summary has a ~1 MiB limit (16× the comment limit).
-- The full plan is always uploaded as a downloadable **artifact** named `tofu-plan` (no practical size limit), so it is accessible even for plans larger than the summary limit.
+- The full plan is uploaded as a downloadable **artifact** named `tofu-plan` (no practical size limit), so it is accessible even for plans larger than the summary limit.
 - On pull requests, a single sticky comment is posted (and updated in place on each push) linking to the run summary page (where the plan is rendered) and to the artifact. This is enabled by default and controlled by `add_github_comment` (set it to `false` to disable). The upstream dflook plan comment is always disabled, since it truncates large plans.
 - On an apply to `main` that requires manual approval, the approval issue created by [manual-approval](https://github.com/trstringer/manual-approval) links to the same plan.
+
+> **Note:** All three surfaces depend on a human-readable plan being produced. For `remote`/`cloud` backends running in auto-approve mode, OpenTofu does not emit a text plan (`text_plan_path` is unset), so the summary, artifact, and comment are skipped.
 
 Because the plan is published before the approval gate, you can review the complete plan and then approve or deny — no need to cancel and re-run.
 
@@ -73,10 +75,11 @@ Because the plan is published before the approval gate, you can review the compl
 
 Most repositories run with the default `GITHUB_TOKEN` permissions, which are sufficient. If you restrict permissions in your workflow, the action needs:
 
+- `contents: read` — required for `actions/checkout` to fetch your configuration.
 - `issues: write` — required for the manual approval gate on `main` (creates and reads the approval issue).
-- `pull-requests: write` — required only when `add_github_comment` is enabled (default), to post the sticky PR comment.
+- `pull-requests: write` — required only when `add_github_comment` is enabled (default), to post the sticky PR comment. Note that PRs opened from forks always receive a read-only token regardless of this setting; in that case the comment is skipped with a warning (the plan is still on the job summary and artifact).
 
-The job summary and the `tofu-plan` artifact require **no** `GITHUB_TOKEN` permissions (the artifact uses the runner's separate token).
+Beyond `contents: read` for checkout, the job summary and the `tofu-plan` artifact need no `GITHUB_TOKEN` write permissions (the artifact upload uses the runner's separate token).
 
 ## Inputs
 
@@ -95,7 +98,7 @@ The job summary and the `tofu-plan` artifact require **no** `GITHUB_TOKEN` permi
 | `destroy` | Create and apply a plan to destroy all resources | ❌ | `false` |
 | `backend_type` | The backend plugin name | ✅ | _None_ |
 | `add_github_comment` | Post a sticky comment on the PR linking to the full plan (job summary / artifact). | ❌ | `true` |
-| `enable_slack_notification_for_approval` | **Deprecated and ignored.** Slack notifications have been removed; retained only for backward compatibility. | ❌ | `true` |
+| `enable_slack_notification_for_approval` | **Deprecated and ignored.** Slack notifications have been removed; retained only for backward compatibility. | ❌ | `""` |
 | `ENABLE_DANGEROUS_AUTO_APPLY_MODE` | If enabled, any changes including Destroy, Apply, and Replace will be automatically approved (skips the manual approval step). | ❌ | `false` |
 
 ## Outputs

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ on:
     branches:
       - main # This action has defaults that assume it will only apply off of main. It will not apply unless you "approve" the github issue per manual-approval GHA.
   pull_request:
-    types: [opened, synchronize, reopened] # If you open a PR it'll run a plan and comment the plan on a PR
+    types: [opened, synchronize, reopened] # If you open a PR it'll run a plan and post a sticky comment linking to the full plan
   workflow_dispatch:
   # schedule:
   #   - cron: '0 16 * * *' # Used for drift detection. However with the manual approval, if drift is found you may burn through your CI requirements while the manual approval actions waits for you to approve or deny the apply.
@@ -69,7 +69,7 @@ GitHub comments are capped at ~64 KB, so posting the plan inline truncates large
 
 > **Note:** All three surfaces depend on a human-readable plan being produced. For `remote`/`cloud` backends running in auto-approve mode, OpenTofu does not emit a text plan (`text_plan_path` is unset), so the summary, artifact, and comment are skipped.
 
-> **When each surface appears:** Pull request runs get all three (job summary, artifact, and the sticky comment). Push-to-`main`, `workflow_dispatch`, and other non-PR runs do **not** post a PR comment (there is no PR to comment on) — the plan is on the job summary and artifact, and on `main` the manual-approval issue links to it. If `ENABLE_DANGEROUS_AUTO_APPLY_MODE` is enabled, the approval issue is skipped too, leaving the job summary and artifact as the surfaces.
+> **When each surface appears:** Pull request runs get the job summary and artifact, plus the sticky comment unless `add_github_comment: false`. Push-to-`main`, `workflow_dispatch`, and other non-PR runs do **not** post a PR comment (there is no PR to comment on) — the plan is on the job summary and artifact, and on `main` the manual-approval issue links to it. If `ENABLE_DANGEROUS_AUTO_APPLY_MODE` is enabled, the approval issue is skipped too, leaving the job summary and artifact as the surfaces.
 
 > **⚠️ Sensitive data:** A plan can contain secrets in cleartext — any provider/resource attribute not explicitly marked `sensitive` (connection strings, IAM policy documents, tokens, etc.) is rendered verbatim. The job summary and the `tofu-plan` artifact are visible to anyone with read/Actions access to the repository, and the artifact is kept per your repository's default artifact retention. Treat them accordingly: restrict repository access and/or lower the artifact retention if your plans can expose sensitive values.
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ jobs:
 - **Push** to `main` branch.
   * Will trigger an apply that will require a manual approval via github issues.
 - **Pull Request** events: opened, synchronized, reopened.
-  *  Pull requests only plan and will post a comment to the PR with the plan results.
+  *  Pull requests only plan and (by default) post a sticky comment to the PR linking to the full plan. See [Viewing the plan](#viewing-the-plan).
 
 ## Job Configuration
 - **Concurrency**: Limits concurrent runs to prevent overlapping runs.
@@ -64,10 +64,19 @@ GitHub comments are capped at ~64 KB, so posting the plan inline truncates large
 
 - The full, human-readable plan is rendered to the run's **job summary** page (browser-viewable, searchable, no download). The summary has a ~1 MiB limit (16× the comment limit).
 - The full plan is always uploaded as a downloadable **artifact** named `tofu-plan` (no practical size limit), so it is accessible even for plans larger than the summary limit.
-- On pull requests, a single sticky comment is posted (and updated in place on each push) linking to the job summary and the artifact. This is enabled by default and controlled by `add_github_comment` (set it to `false` to disable). The upstream dflook plan comment is always disabled, since it truncates large plans.
+- On pull requests, a single sticky comment is posted (and updated in place on each push) linking to the run summary page (where the plan is rendered) and to the artifact. This is enabled by default and controlled by `add_github_comment` (set it to `false` to disable). The upstream dflook plan comment is always disabled, since it truncates large plans.
 - On an apply to `main` that requires manual approval, the approval issue created by [manual-approval](https://github.com/trstringer/manual-approval) links to the same plan.
 
 Because the plan is published before the approval gate, you can review the complete plan and then approve or deny — no need to cancel and re-run.
+
+## Permissions
+
+Most repositories run with the default `GITHUB_TOKEN` permissions, which are sufficient. If you restrict permissions in your workflow, the action needs:
+
+- `issues: write` — required for the manual approval gate on `main` (creates and reads the approval issue).
+- `pull-requests: write` — required only when `add_github_comment` is enabled (default), to post the sticky PR comment.
+
+The job summary and the `tofu-plan` artifact require **no** `GITHUB_TOKEN` permissions (the artifact uses the runner's separate token).
 
 ## Inputs
 

--- a/README.md
+++ b/README.md
@@ -69,12 +69,12 @@ jobs:
 GitHub issue and comment bodies are capped at **65,536 characters**, so a large plan can't always be posted inline. The action handles this as follows:
 
 - The full plan is **always** uploaded as a downloadable **artifact** named `tofu-plan.txt`. It is uploaded uncompressed (`archive: false`), so it downloads as a single `.txt` file with no zip to extract, and has no practical size limit.
-- On pull requests, a single sticky comment is posted (and updated in place on each push) that **always** has a one-click link to download the artifact, and **also inlines the full plan** (in a collapsible block) **when the whole comment fits** under the 65,536-character limit. If the plan is too large to fit, the comment is link-only — it never includes a partial plan. Controlled by `add_github_comment` (default `true`; set `false` to disable). The upstream dflook plan comment is always disabled, since it truncates large plans.
-- On an apply to `main` that requires manual approval, the approval issue created by [manual-approval](https://github.com/trstringer/manual-approval) does the same: always a one-click artifact download link, plus the inlined plan when it fits.
+- On pull requests, a single sticky comment is posted (and updated in place on each push) that **always** has a link to download the artifact, and **also inlines the full plan** (in a collapsible block) **when the whole comment fits** under the 65,536-character limit. If the plan is too large to fit, the comment is link-only — it never includes a partial plan. Controlled by `add_github_comment` (default `true`; set `false` to disable). The upstream dflook plan comment is always disabled, since it truncates large plans.
+- On an apply to `main` that requires manual approval, [manual-approval](https://github.com/trstringer/manual-approval) posts the same content as a **comment on the approval issue**: always the artifact download link, plus the inlined plan when it fits.
 
 > **Note:** Both surfaces depend on a human-readable plan being produced. For `remote`/`cloud` backends running in auto-approve mode, OpenTofu emits no text plan (`text_plan_path` is unset), so the artifact and the inline plan are skipped. Non-PR runs (`push` to `main`, `workflow_dispatch`) post no PR comment; the plan is on the artifact, and on `main` the approval issue links to it.
 
-> **⚠️ Sensitive data:** A plan can contain secrets in cleartext — any provider/resource attribute not explicitly marked `sensitive` (connection strings, IAM policy documents, tokens, etc.) is rendered verbatim. The `tofu-plan.txt` artifact — and the plan inlined in the PR comment / approval issue when small enough — are visible to anyone with read/Actions access to the repository, and the artifact is kept per your repository's default artifact retention. Treat them accordingly: restrict repository access and/or lower the artifact retention if your plans can expose sensitive values.
+> **⚠️ Sensitive data:** A plan can contain secrets in cleartext — any provider/resource attribute not explicitly marked `sensitive` (connection strings, IAM policy documents, tokens, etc.) is rendered verbatim. The `tofu-plan.txt` artifact — and the plan inlined in the PR comment / approval issue when small enough — are visible to anyone with read/Actions access to the repository. Because the plan is also posted as a comment/issue, the full body is additionally delivered via GitHub **email/push notifications** to PR and issue subscribers. The artifact is kept per your repository's default artifact retention. Treat all of these accordingly: restrict repository access, watch who is subscribed, and/or lower the artifact retention if your plans can expose sensitive values.
 
 Because the artifact and the comment/issue are produced before the approval gate, you can review the plan and then approve or deny — no need to cancel and re-run.
 
@@ -104,7 +104,7 @@ Beyond `contents: read` for checkout, the `tofu-plan.txt` artifact needs no `GIT
 | `replace` | List of resources to replace if an update is required, one per line | ❌ | `""` |
 | `destroy` | Create and apply a plan to destroy all resources | ❌ | `false` |
 | `backend_type` | The backend plugin name | ✅ | _None_ |
-| `add_github_comment` | Post a sticky comment on the PR linking to the full plan (job summary / artifact). | ❌ | `true` |
+| `add_github_comment` | Post a sticky PR comment with the plan (inlined when it fits, otherwise a link to the `tofu-plan.txt` artifact). | ❌ | `true` |
 | `enable_slack_notification_for_approval` | **Deprecated and ignored.** Slack notifications have been removed; retained only for backward compatibility. | ❌ | `""` |
 | `ENABLE_DANGEROUS_AUTO_APPLY_MODE` | If enabled, any changes including Destroy, Apply, and Replace will be automatically approved (skips the manual approval step). | ❌ | `false` |
 

--- a/README.md
+++ b/README.md
@@ -66,12 +66,12 @@ jobs:
 
 ## Viewing the plan
 
-GitHub comments are capped at ~64 KB, so posting the plan inline truncates large plans. Instead, the full plan is made available without that limit, and every surface just **links** to it consistently:
+GitHub comments are capped at ~64 KB, so posting the plan inline truncates large plans. Instead, the full plan is made available without that limit, and the PR comment / approval issue link to it:
 
 - The full, human-readable plan is rendered to the run's **job summary** page (browser-viewable, searchable, no download). The summary has a ~1 MiB limit (16× the comment limit). Note that GitHub only renders the job summary **after the job finishes**.
 - The full plan is uploaded as a downloadable **artifact** named `tofu-plan.txt` (no practical size limit), so it is accessible even for plans larger than the summary limit. It is uploaded uncompressed (`archive: false`), so it downloads as a single `.txt` file with no zip to extract.
-- On pull requests, a single sticky comment is posted (and updated in place on each push) linking to the run summary page (where the plan is rendered) and to the artifact. This is enabled by default and controlled by `add_github_comment` (set it to `false` to disable). The upstream dflook plan comment is always disabled, since it truncates large plans.
-- On an apply to `main` that requires manual approval, the approval issue created by [manual-approval](https://github.com/trstringer/manual-approval) links to the same plan.
+- On pull requests, a single sticky comment is posted (and updated in place on each push) with a one-click link to download the plan artifact (`tofu-plan.txt`). This is enabled by default and controlled by `add_github_comment` (set it to `false` to disable). The upstream dflook plan comment is always disabled, since it truncates large plans.
+- On an apply to `main` that requires manual approval, the approval issue created by [manual-approval](https://github.com/trstringer/manual-approval) carries the same one-click link to download the plan artifact.
 
 > **Reviewing before approval:** because the job summary only renders after the job finishes, it is **not** viewable while the run is paused at the manual-approval gate on `main`. To review the plan before approving, download the `tofu-plan.txt` artifact (available during the pause) or expand the `tofu plan` step in the live job logs.
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,10 @@ GitHub comments are capped at ~64 KB, so posting the plan inline truncates large
 
 > **Note:** All three surfaces depend on a human-readable plan being produced. For `remote`/`cloud` backends running in auto-approve mode, OpenTofu does not emit a text plan (`text_plan_path` is unset), so the summary, artifact, and comment are skipped.
 
+> **When each surface appears:** Pull request runs get all three (job summary, artifact, and the sticky comment). Push-to-`main`, `workflow_dispatch`, and other non-PR runs do **not** post a PR comment (there is no PR to comment on) — the plan is on the job summary and artifact, and on `main` the manual-approval issue links to it. If `ENABLE_DANGEROUS_AUTO_APPLY_MODE` is enabled, the approval issue is skipped too, leaving the job summary and artifact as the surfaces.
+
+> **⚠️ Sensitive data:** A plan can contain secrets in cleartext — any provider/resource attribute not explicitly marked `sensitive` (connection strings, IAM policy documents, tokens, etc.) is rendered verbatim. The job summary and the `tofu-plan` artifact are visible to anyone with read/Actions access to the repository, and the artifact is kept per your repository's default artifact retention. Treat them accordingly: restrict repository access and/or lower the artifact retention if your plans can expose sensitive values.
+
 Because the plan is published before the approval gate, you can review the complete plan and then approve or deny — no need to cancel and re-run.
 
 ## Permissions

--- a/README.md
+++ b/README.md
@@ -60,12 +60,14 @@ jobs:
 
 ## Viewing the plan
 
-The plan is posted as a PR/commit comment via `add_github_comment`. GitHub comments are capped at ~64 KB, so large plans get truncated there. To make the full plan available regardless of size, every run also:
+GitHub comments are capped at ~64 KB, so posting the plan inline truncates large plans. Instead, the full plan is always made available without that limit, and every surface just **links** to it consistently:
 
-- Renders the full, human-readable plan to the **job summary** page of the run (browser-viewable, searchable, no download).
-- Uploads the full plan as a downloadable **artifact** named `tofu-plan` (no practical size limit; fallback for very large plans).
+- The full, human-readable plan is rendered to the run's **job summary** page (browser-viewable, searchable, no download). The summary has a ~1 MiB limit (16× the comment limit).
+- The full plan is always uploaded as a downloadable **artifact** named `tofu-plan` (no practical size limit), so it is accessible even for plans larger than the summary limit.
+- On pull requests, a single sticky comment is posted (and updated in place on each push) linking to the job summary and the artifact. This is controlled by `add_github_comment`.
+- On an apply to `main` that requires manual approval, the approval issue created by [manual-approval](https://github.com/trstringer/manual-approval) links to the same plan.
 
-When an apply on `main` requires manual approval, the approval issue created by [manual-approval](https://github.com/trstringer/manual-approval) links directly to both the job summary and the artifact, so you can review the complete plan before approving — no need to cancel and re-run.
+Because the plan is published before the approval gate, you can review the complete plan and then approve or deny — no need to cancel and re-run.
 
 ## Inputs
 
@@ -83,7 +85,7 @@ When an apply on `main` requires manual approval, the approval issue created by 
 | `replace` | List of resources to replace if an update is required, one per line | ❌ | `""` |
 | `destroy` | Create and apply a plan to destroy all resources | ❌ | `false` |
 | `backend_type` | The backend plugin name | ✅ | _None_ |
-| `add_github_comment` | Add the plan to a GitHub PR | ❌ | `true` |
+| `add_github_comment` | Post a sticky comment on the PR linking to the full plan (job summary / artifact). | ❌ | `true` |
 | `enable_slack_notification_for_approval` | **Deprecated and ignored.** Slack notifications have been removed; retained only for backward compatibility. | ❌ | `true` |
 | `ENABLE_DANGEROUS_AUTO_APPLY_MODE` | If enabled, any changes including Destroy, Apply, and Replace will be automatically approved (skips the manual approval step). | ❌ | `false` |
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ GitHub comments are capped at ~64 KB, so posting the plan inline truncates large
 
 - The full, human-readable plan is rendered to the run's **job summary** page (browser-viewable, searchable, no download). The summary has a ~1 MiB limit (16× the comment limit).
 - The full plan is always uploaded as a downloadable **artifact** named `tofu-plan` (no practical size limit), so it is accessible even for plans larger than the summary limit.
-- On pull requests, a single sticky comment can be posted (and updated in place on each push) linking to the job summary and the artifact. This is controlled by `add_github_comment` and is **disabled by default** (the plan is already on the job summary / artifact); set it to `true` to enable.
+- On pull requests, a single sticky comment is posted (and updated in place on each push) linking to the job summary and the artifact. This is enabled by default and controlled by `add_github_comment` (set it to `false` to disable). The upstream dflook plan comment is always disabled, since it truncates large plans.
 - On an apply to `main` that requires manual approval, the approval issue created by [manual-approval](https://github.com/trstringer/manual-approval) links to the same plan.
 
 Because the plan is published before the approval gate, you can review the complete plan and then approve or deny — no need to cancel and re-run.
@@ -85,7 +85,7 @@ Because the plan is published before the approval gate, you can review the compl
 | `replace` | List of resources to replace if an update is required, one per line | ❌ | `""` |
 | `destroy` | Create and apply a plan to destroy all resources | ❌ | `false` |
 | `backend_type` | The backend plugin name | ✅ | _None_ |
-| `add_github_comment` | Post a sticky comment on the PR linking to the full plan (job summary / artifact). | ❌ | `false` |
+| `add_github_comment` | Post a sticky comment on the PR linking to the full plan (job summary / artifact). | ❌ | `true` |
 | `enable_slack_notification_for_approval` | **Deprecated and ignored.** Slack notifications have been removed; retained only for backward compatibility. | ❌ | `true` |
 | `ENABLE_DANGEROUS_AUTO_APPLY_MODE` | If enabled, any changes including Destroy, Apply, and Replace will be automatically approved (skips the manual approval step). | ❌ | `false` |
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # OpenTofu - Continuous Delivery
 
+[![Integration Test](https://github.com/GlueOps/github-actions-opentofu-continuous-delivery/actions/workflows/integration-test.yml/badge.svg)](https://github.com/GlueOps/github-actions-opentofu-continuous-delivery/actions/workflows/integration-test.yml)
+
 ## Introduction
 
 This action is an opinionated wrapper around the work of Daniel Flook: https://github.com/dflook/terraform-github-actions and leverages https://github.com/trstringer/manual-approval as the approval step before applying.

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ GitHub comments are capped at ~64 KB, so posting the plan inline truncates large
 
 - The full, human-readable plan is rendered to the run's **job summary** page (browser-viewable, searchable, no download). The summary has a ~1 MiB limit (16× the comment limit).
 - The full plan is always uploaded as a downloadable **artifact** named `tofu-plan` (no practical size limit), so it is accessible even for plans larger than the summary limit.
-- On pull requests, a single sticky comment is posted (and updated in place on each push) linking to the job summary and the artifact. This is controlled by `add_github_comment`.
+- On pull requests, a single sticky comment can be posted (and updated in place on each push) linking to the job summary and the artifact. This is controlled by `add_github_comment` and is **disabled by default** (the plan is already on the job summary / artifact); set it to `true` to enable.
 - On an apply to `main` that requires manual approval, the approval issue created by [manual-approval](https://github.com/trstringer/manual-approval) links to the same plan.
 
 Because the plan is published before the approval gate, you can review the complete plan and then approve or deny — no need to cancel and re-run.
@@ -85,7 +85,7 @@ Because the plan is published before the approval gate, you can review the compl
 | `replace` | List of resources to replace if an update is required, one per line | ❌ | `""` |
 | `destroy` | Create and apply a plan to destroy all resources | ❌ | `false` |
 | `backend_type` | The backend plugin name | ✅ | _None_ |
-| `add_github_comment` | Post a sticky comment on the PR linking to the full plan (job summary / artifact). | ❌ | `true` |
+| `add_github_comment` | Post a sticky comment on the PR linking to the full plan (job summary / artifact). | ❌ | `false` |
 | `enable_slack_notification_for_approval` | **Deprecated and ignored.** Slack notifications have been removed; retained only for backward compatibility. | ❌ | `true` |
 | `ENABLE_DANGEROUS_AUTO_APPLY_MODE` | If enabled, any changes including Destroy, Apply, and Replace will be automatically approved (skips the manual approval step). | ❌ | `false` |
 

--- a/README.md
+++ b/README.md
@@ -68,10 +68,12 @@ jobs:
 
 GitHub comments are capped at ~64 KB, so posting the plan inline truncates large plans. Instead, the full plan is made available without that limit, and every surface just **links** to it consistently:
 
-- The full, human-readable plan is rendered to the run's **job summary** page (browser-viewable, searchable, no download). The summary has a ~1 MiB limit (16× the comment limit).
+- The full, human-readable plan is rendered to the run's **job summary** page (browser-viewable, searchable, no download). The summary has a ~1 MiB limit (16× the comment limit). Note that GitHub only renders the job summary **after the job finishes**.
 - The full plan is uploaded as a downloadable **artifact** named `tofu-plan` (no practical size limit), so it is accessible even for plans larger than the summary limit.
 - On pull requests, a single sticky comment is posted (and updated in place on each push) linking to the run summary page (where the plan is rendered) and to the artifact. This is enabled by default and controlled by `add_github_comment` (set it to `false` to disable). The upstream dflook plan comment is always disabled, since it truncates large plans.
 - On an apply to `main` that requires manual approval, the approval issue created by [manual-approval](https://github.com/trstringer/manual-approval) links to the same plan.
+
+> **Reviewing before approval:** because the job summary only renders after the job finishes, it is **not** viewable while the run is paused at the manual-approval gate on `main`. To review the plan before approving, download the `tofu-plan` artifact (available during the pause) or expand the `tofu plan` step in the live job logs.
 
 > **Note:** All three surfaces depend on a human-readable plan being produced. For `remote`/`cloud` backends running in auto-approve mode, OpenTofu does not emit a text plan (`text_plan_path` is unset), so the summary, artifact, and comment are skipped.
 

--- a/README.md
+++ b/README.md
@@ -66,22 +66,17 @@ jobs:
 
 ## Viewing the plan
 
-GitHub comments are capped at ~64 KB, so posting the plan inline truncates large plans. Instead, the full plan is made available without that limit, and the PR comment / approval issue link to it:
+GitHub issue and comment bodies are capped at **65,536 characters**, so a large plan can't always be posted inline. The action handles this as follows:
 
-- The full, human-readable plan is rendered to the run's **job summary** page (browser-viewable, searchable, no download). The summary has a ~1 MiB limit (16× the comment limit). Note that GitHub only renders the job summary **after the job finishes**.
-- The full plan is uploaded as a downloadable **artifact** named `tofu-plan.txt` (no practical size limit), so it is accessible even for plans larger than the summary limit. It is uploaded uncompressed (`archive: false`), so it downloads as a single `.txt` file with no zip to extract.
-- On pull requests, a single sticky comment is posted (and updated in place on each push) with a one-click link to download the plan artifact (`tofu-plan.txt`). This is enabled by default and controlled by `add_github_comment` (set it to `false` to disable). The upstream dflook plan comment is always disabled, since it truncates large plans.
-- On an apply to `main` that requires manual approval, the approval issue created by [manual-approval](https://github.com/trstringer/manual-approval) carries the same one-click link to download the plan artifact.
+- The full plan is **always** uploaded as a downloadable **artifact** named `tofu-plan.txt`. It is uploaded uncompressed (`archive: false`), so it downloads as a single `.txt` file with no zip to extract, and has no practical size limit.
+- On pull requests, a single sticky comment is posted (and updated in place on each push) that **always** has a one-click link to download the artifact, and **also inlines the full plan** (in a collapsible block) **when the whole comment fits** under the 65,536-character limit. If the plan is too large to fit, the comment is link-only — it never includes a partial plan. Controlled by `add_github_comment` (default `true`; set `false` to disable). The upstream dflook plan comment is always disabled, since it truncates large plans.
+- On an apply to `main` that requires manual approval, the approval issue created by [manual-approval](https://github.com/trstringer/manual-approval) does the same: always a one-click artifact download link, plus the inlined plan when it fits.
 
-> **Reviewing before approval:** because the job summary only renders after the job finishes, it is **not** viewable while the run is paused at the manual-approval gate on `main`. To review the plan before approving, download the `tofu-plan.txt` artifact (available during the pause) or expand the `tofu plan` step in the live job logs.
+> **Note:** Both surfaces depend on a human-readable plan being produced. For `remote`/`cloud` backends running in auto-approve mode, OpenTofu emits no text plan (`text_plan_path` is unset), so the artifact and the inline plan are skipped. Non-PR runs (`push` to `main`, `workflow_dispatch`) post no PR comment; the plan is on the artifact, and on `main` the approval issue links to it.
 
-> **Note:** All three surfaces depend on a human-readable plan being produced. For `remote`/`cloud` backends running in auto-approve mode, OpenTofu does not emit a text plan (`text_plan_path` is unset), so the summary, artifact, and comment are skipped.
+> **⚠️ Sensitive data:** A plan can contain secrets in cleartext — any provider/resource attribute not explicitly marked `sensitive` (connection strings, IAM policy documents, tokens, etc.) is rendered verbatim. The `tofu-plan.txt` artifact — and the plan inlined in the PR comment / approval issue when small enough — are visible to anyone with read/Actions access to the repository, and the artifact is kept per your repository's default artifact retention. Treat them accordingly: restrict repository access and/or lower the artifact retention if your plans can expose sensitive values.
 
-> **When each surface appears:** Pull request runs get the job summary and artifact, plus the sticky comment unless `add_github_comment: false`. Push-to-`main`, `workflow_dispatch`, and other non-PR runs do **not** post a PR comment (there is no PR to comment on) — the plan is on the job summary and artifact, and on `main` the manual-approval issue links to it. If `ENABLE_DANGEROUS_AUTO_APPLY_MODE` is enabled, the approval issue is skipped too, leaving the job summary and artifact as the surfaces.
-
-> **⚠️ Sensitive data:** A plan can contain secrets in cleartext — any provider/resource attribute not explicitly marked `sensitive` (connection strings, IAM policy documents, tokens, etc.) is rendered verbatim. The job summary and the `tofu-plan.txt` artifact are visible to anyone with read/Actions access to the repository, and the artifact is kept per your repository's default artifact retention. Treat them accordingly: restrict repository access and/or lower the artifact retention if your plans can expose sensitive values.
-
-Because the plan is published before the approval gate, you can review the complete plan and then approve or deny — no need to cancel and re-run.
+Because the artifact and the comment/issue are produced before the approval gate, you can review the plan and then approve or deny — no need to cancel and re-run.
 
 ## Permissions
 
@@ -89,9 +84,9 @@ Most repositories run with the default `GITHUB_TOKEN` permissions, which are suf
 
 - `contents: read` — required for `actions/checkout` to fetch your configuration.
 - `issues: write` — required for the manual approval gate on `main` (creates and reads the approval issue).
-- `pull-requests: write` — required only when `add_github_comment` is enabled (default), to post the sticky PR comment. Note that PRs opened from forks always receive a read-only token regardless of this setting; in that case the comment is skipped with a warning (the plan is still on the job summary and artifact).
+- `pull-requests: write` — required only when `add_github_comment` is enabled (default), to post the sticky PR comment. Note that PRs opened from forks always receive a read-only token regardless of this setting; in that case the comment is skipped with a warning (the plan is still on the artifact).
 
-Beyond `contents: read` for checkout, the job summary and the `tofu-plan.txt` artifact need no `GITHUB_TOKEN` write permissions (the artifact upload uses the runner's separate token).
+Beyond `contents: read` for checkout, the `tofu-plan.txt` artifact needs no `GITHUB_TOKEN` write permissions (the artifact upload uses the runner's separate token).
 
 ## Inputs
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ jobs:
 
 GitHub issue and comment bodies are capped at **65,536 characters**, so a large plan can't always be posted inline. The action handles this as follows:
 
-- The full plan is **always** uploaded as a downloadable **artifact** named `tofu-plan.txt`. It is uploaded uncompressed (`archive: false`), so it downloads as a single `.txt` file with no zip to extract, and has no practical size limit.
+- Whenever a text plan is produced, the full plan is uploaded as a downloadable **artifact** named `tofu-plan.txt`. It is uploaded uncompressed (`archive: false`), so it downloads as a single `.txt` file with no zip to extract, and has no practical size limit. (See the note below for the one case where no text plan exists.)
 - On pull requests, a single sticky comment is posted (and updated in place on each push) that **always** has a link to download the artifact, and **also inlines the full plan** (in a collapsible block) **when the whole comment fits** under the 65,536-character limit. If the plan is too large to fit, the comment is link-only — it never includes a partial plan. Controlled by `add_github_comment` (default `true`; set `false` to disable). The upstream dflook plan comment is always disabled, since it truncates large plans.
 - On an apply to `main` that requires manual approval, [manual-approval](https://github.com/trstringer/manual-approval) posts the same content as a **comment on the approval issue**: always the artifact download link, plus the inlined plan when it fits.
 

--- a/README.md
+++ b/README.md
@@ -69,17 +69,17 @@ jobs:
 GitHub comments are capped at ~64 KB, so posting the plan inline truncates large plans. Instead, the full plan is made available without that limit, and every surface just **links** to it consistently:
 
 - The full, human-readable plan is rendered to the run's **job summary** page (browser-viewable, searchable, no download). The summary has a ~1 MiB limit (16× the comment limit). Note that GitHub only renders the job summary **after the job finishes**.
-- The full plan is uploaded as a downloadable **artifact** named `tofu-plan` (no practical size limit), so it is accessible even for plans larger than the summary limit.
+- The full plan is uploaded as a downloadable **artifact** named `tofu-plan.txt` (no practical size limit), so it is accessible even for plans larger than the summary limit. It is uploaded uncompressed (`archive: false`), so it downloads as a single `.txt` file with no zip to extract.
 - On pull requests, a single sticky comment is posted (and updated in place on each push) linking to the run summary page (where the plan is rendered) and to the artifact. This is enabled by default and controlled by `add_github_comment` (set it to `false` to disable). The upstream dflook plan comment is always disabled, since it truncates large plans.
 - On an apply to `main` that requires manual approval, the approval issue created by [manual-approval](https://github.com/trstringer/manual-approval) links to the same plan.
 
-> **Reviewing before approval:** because the job summary only renders after the job finishes, it is **not** viewable while the run is paused at the manual-approval gate on `main`. To review the plan before approving, download the `tofu-plan` artifact (available during the pause) or expand the `tofu plan` step in the live job logs.
+> **Reviewing before approval:** because the job summary only renders after the job finishes, it is **not** viewable while the run is paused at the manual-approval gate on `main`. To review the plan before approving, download the `tofu-plan.txt` artifact (available during the pause) or expand the `tofu plan` step in the live job logs.
 
 > **Note:** All three surfaces depend on a human-readable plan being produced. For `remote`/`cloud` backends running in auto-approve mode, OpenTofu does not emit a text plan (`text_plan_path` is unset), so the summary, artifact, and comment are skipped.
 
 > **When each surface appears:** Pull request runs get the job summary and artifact, plus the sticky comment unless `add_github_comment: false`. Push-to-`main`, `workflow_dispatch`, and other non-PR runs do **not** post a PR comment (there is no PR to comment on) — the plan is on the job summary and artifact, and on `main` the manual-approval issue links to it. If `ENABLE_DANGEROUS_AUTO_APPLY_MODE` is enabled, the approval issue is skipped too, leaving the job summary and artifact as the surfaces.
 
-> **⚠️ Sensitive data:** A plan can contain secrets in cleartext — any provider/resource attribute not explicitly marked `sensitive` (connection strings, IAM policy documents, tokens, etc.) is rendered verbatim. The job summary and the `tofu-plan` artifact are visible to anyone with read/Actions access to the repository, and the artifact is kept per your repository's default artifact retention. Treat them accordingly: restrict repository access and/or lower the artifact retention if your plans can expose sensitive values.
+> **⚠️ Sensitive data:** A plan can contain secrets in cleartext — any provider/resource attribute not explicitly marked `sensitive` (connection strings, IAM policy documents, tokens, etc.) is rendered verbatim. The job summary and the `tofu-plan.txt` artifact are visible to anyone with read/Actions access to the repository, and the artifact is kept per your repository's default artifact retention. Treat them accordingly: restrict repository access and/or lower the artifact retention if your plans can expose sensitive values.
 
 Because the plan is published before the approval gate, you can review the complete plan and then approve or deny — no need to cancel and re-run.
 
@@ -91,7 +91,7 @@ Most repositories run with the default `GITHUB_TOKEN` permissions, which are suf
 - `issues: write` — required for the manual approval gate on `main` (creates and reads the approval issue).
 - `pull-requests: write` — required only when `add_github_comment` is enabled (default), to post the sticky PR comment. Note that PRs opened from forks always receive a read-only token regardless of this setting; in that case the comment is skipped with a warning (the plan is still on the job summary and artifact).
 
-Beyond `contents: read` for checkout, the job summary and the `tofu-plan` artifact need no `GITHUB_TOKEN` write permissions (the artifact upload uses the runner's separate token).
+Beyond `contents: read` for checkout, the job summary and the `tofu-plan.txt` artifact need no `GITHUB_TOKEN` write permissions (the artifact upload uses the runner's separate token).
 
 ## Inputs
 

--- a/action.yml
+++ b/action.yml
@@ -197,8 +197,13 @@ runs:
           ].join('\n');
           const { owner, repo } = context.repo;
           const issue_number = context.issue.number;
-          const comments = await github.paginate(github.rest.issues.listComments, { owner, repo, issue_number });
-          const existing = comments.find(c => c.body && c.body.includes(marker));
+          // Scan pages and stop as soon as the marker is found, rather than
+          // eagerly fetching every comment (faster on large PRs).
+          let existing;
+          for await (const { data: page } of github.paginate.iterator(github.rest.issues.listComments, { owner, repo, issue_number, per_page: 100 })) {
+            existing = page.find(c => c.body && c.body.includes(marker));
+            if (existing) break;
+          }
           if (existing) {
             await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
           } else {

--- a/action.yml
+++ b/action.yml
@@ -231,8 +231,7 @@ runs:
             marker,
             '## OpenTofu Plan',
             '',
-            `- 📄 View the plan in the run summary: ${process.env.SUMMARY_URL}`,
-            `- ⬇️ Download the full plan (one click, tofu-plan.txt): ${process.env.ARTIFACT_URL}`,
+            `⬇️ Download the full plan (one click, tofu-plan.txt): ${process.env.ARTIFACT_URL}`,
           ].join('\n');
           const { owner, repo } = context.repo;
           const issue_number = context.issue.number;
@@ -259,7 +258,6 @@ runs:
             core.warning(`Could not post the plan comment; the plan is still on the job summary and the tofu-plan artifact. Expected for fork PRs (read-only token); for same-repo PRs ensure the workflow grants 'pull-requests: write'. Error: ${e.message}`);
           }
       env:
-        SUMMARY_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         ARTIFACT_URL: ${{ steps.upload_plan.outputs.artifact-url }}
 
     ## IMPORTANT
@@ -275,8 +273,7 @@ runs:
         issue-body: |
           Approve or Deny tofu apply. Review the plan before approving:
 
-          - ⬇️ Download the full plan (one click, tofu-plan.txt): ${{ steps.upload_plan.outputs.artifact-url }}
-          - 📄 Plan in the run summary (renders after the job finishes): ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          ⬇️ Download the full plan (one click, tofu-plan.txt): ${{ steps.upload_plan.outputs.artifact-url }}
         exclude-workflow-initiator-as-approver: false
 
     - name: tofu apply

--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,7 @@ inputs:
   variables:
     description: Variable definitions
     required: false
+    default: ""
   var_file:
     description: List of var file paths, one per line
     required: false
@@ -97,7 +98,7 @@ outputs:
     value: ${{ steps.plan.outputs.run_id }}
   failure-reason:
     description: The reason for the build failure. May be `apply-failed` or `plan-changed`.
-    value: ${{ steps.plan.outputs.failure-reason || steps.apply.outputs.failure-reason }}
+    value: ${{ steps.apply.outputs.failure-reason }}
 
 
 runs:

--- a/action.yml
+++ b/action.yml
@@ -272,9 +272,10 @@ runs:
             // eagerly fetching every comment (faster on large PRs).
             let existing;
             for await (const { data: page } of github.paginate.iterator(github.rest.issues.listComments, { owner, repo, issue_number, per_page: 100 })) {
-              // Require the bot to own the comment so a human-planted marker
-              // can't redirect our update onto their comment.
-              existing = page.find(c => c.body && c.body.includes(marker) && c.user && c.user.type === 'Bot');
+              // Require our own bot (github.token posts as github-actions[bot])
+              // to own the comment, so a human- or other-bot-planted marker can't
+              // redirect our update onto their comment.
+              existing = page.find(c => c.body && c.body.includes(marker) && c.user && c.user.login === 'github-actions[bot]');
               if (existing) break;
             }
             if (existing) {

--- a/action.yml
+++ b/action.yml
@@ -229,22 +229,24 @@ runs:
           printf '\n%s\n\n</details>\n' "$fence"
         }
 
-        # PR comment: header + link, plus the inline plan only if the whole fits.
-        { printf '%s\n## OpenTofu Plan\n\n%s\n' "$marker" "$link"; emit_plan; } > "${pr}.full"
+        # PR comment: link first (after the invisible marker), then header, plus
+        # the inline plan only if the whole body fits.
+        { printf '%s\n%s\n\n## OpenTofu Plan\n' "$marker" "$link"; emit_plan; } > "${pr}.full"
         if [ "$(wc -c < "${pr}.full")" -le "$max" ]; then
           mv "${pr}.full" "$pr"
         else
-          printf '%s\n## OpenTofu Plan\n\n%s\n' "$marker" "$link" > "$pr"
+          printf '%s\n%s\n\n## OpenTofu Plan\n\n_Plan too large to inline — use the download link above._\n' "$marker" "$link" > "$pr"
           rm -f "${pr}.full"
         fi
 
-        # Approval issue: preamble + link, plus the inline plan only if it all fits.
+        # Approval issue: link first, then the approve/deny context, plus the inline
+        # plan only if it all fits.
         preamble='Approve or Deny tofu apply. Review the plan before approving:'
-        { printf '%s\n\n%s\n' "$preamble" "$link"; emit_plan; } > "${iss}.full"
+        { printf '%s\n\n%s\n' "$link" "$preamble"; emit_plan; } > "${iss}.full"
         if [ "$(wc -c < "${iss}.full")" -le "$max" ]; then
           mv "${iss}.full" "$iss"
         else
-          printf '%s\n\n%s\n' "$preamble" "$link" > "$iss"
+          printf '%s\n\n%s\n\n_Plan too large to inline — use the download link above._\n' "$link" "$preamble" > "$iss"
           rm -f "${iss}.full"
         fi
 

--- a/action.yml
+++ b/action.yml
@@ -167,31 +167,6 @@ runs:
         # below (gated on the add_github_comment input) instead.
         add_github_comment: "false"
 
-    # Publishes the full, human-readable plan to the run's job summary page so it
-    # can be read in the browser without downloading anything or re-running.
-    - name: Publish full plan to job summary
-      if: steps.plan.outputs.text_plan_path != ''
-      shell: bash
-      env:
-        # Pass via env (not inline ${{ }}) to avoid shell-injection from the value.
-        PLAN_PATH: ${{ steps.plan.outputs.text_plan_path }}
-      run: |
-        # Choose a code fence longer than the longest run of backticks in the
-        # plan, so a plan line that itself contains ``` cannot close the block.
-        longest=$(grep -oE '`+' "$PLAN_PATH" | awk '{ if (length > m) m = length } END { print m+0 }' || true)
-        len=3
-        if [ "${longest:-0}" -ge 3 ]; then len=$((longest + 1)); fi
-        fence=$(printf '%*s' "$len" '' | tr ' ' '`')
-        {
-          echo '## OpenTofu Plan'
-          echo "$fence"
-          cat "$PLAN_PATH"
-          # Ensure the closing fence is on its own line even if the plan file
-          # has no trailing newline (otherwise the code block never closes).
-          printf '\n'
-          echo "$fence"
-        } >> "$GITHUB_STEP_SUMMARY"
-
     # Copy the plan to a clean, predictable filename. With archive: false the
     # uploaded file's name becomes the artifact name (the name: input is ignored),
     # so we set it here. Path is passed via env to avoid shell injection.
@@ -217,6 +192,65 @@ runs:
         path: ${{ steps.stage_plan.outputs.path }}
         archive: false
 
+    # Builds the PR-comment and approval-issue bodies: always a one-click link to
+    # the artifact, plus the full plan inlined ONLY when the whole body stays under
+    # GitHub's 65,536-char body limit (otherwise link-only — never a partial plan).
+    - name: Build plan comment and approval issue bodies
+      id: bodies
+      if: steps.plan.outputs.text_plan_path != ''
+      shell: bash
+      env:
+        PLAN_PATH: ${{ steps.plan.outputs.text_plan_path }}
+        ARTIFACT_URL: ${{ steps.upload_plan.outputs.artifact-url }}
+      run: |
+        # GitHub issue/comment bodies are capped at 65,536 characters. Stay under
+        # it with margin; byte count is a safe proxy (UTF-8 bytes >= characters).
+        max=64000
+        marker='<!-- glueops-opentofu-plan -->'
+        link="⬇️ Download the full plan (one click, tofu-plan.txt): ${ARTIFACT_URL}"
+
+        # Backtick-safe fence longer than the longest run of backticks in the plan.
+        longest=$(grep -oE '`+' "$PLAN_PATH" | awk '{ if (length > m) m = length } END { print m+0 }' || true)
+        len=3
+        if [ "${longest:-0}" -ge 3 ]; then len=$((longest + 1)); fi
+        fence=$(printf '%*s' "$len" '' | tr ' ' '`')
+
+        # github-script (Node) reads the PR body from RUNNER_TEMP; manual-approval
+        # (a Docker action) can only read files under the workspace, so the issue
+        # body lives there and is passed as a path relative to /github/workspace.
+        pr="${RUNNER_TEMP}/glueops_pr_comment.md"
+        iss_rel='.glueops_approval_issue.md'
+        iss="${GITHUB_WORKSPACE}/${iss_rel}"
+
+        emit_plan() {
+          printf '\n<details><summary>Show plan</summary>\n\n%s\n' "$fence"
+          cat "$PLAN_PATH"
+          # Force a newline so the closing fence is on its own line.
+          printf '\n%s\n\n</details>\n' "$fence"
+        }
+
+        # PR comment: header + link, plus the inline plan only if the whole fits.
+        { printf '%s\n## OpenTofu Plan\n\n%s\n' "$marker" "$link"; emit_plan; } > "${pr}.full"
+        if [ "$(wc -c < "${pr}.full")" -le "$max" ]; then
+          mv "${pr}.full" "$pr"
+        else
+          printf '%s\n## OpenTofu Plan\n\n%s\n' "$marker" "$link" > "$pr"
+          rm -f "${pr}.full"
+        fi
+
+        # Approval issue: preamble + link, plus the inline plan only if it all fits.
+        preamble='Approve or Deny tofu apply. Review the plan before approving:'
+        { printf '%s\n\n%s\n' "$preamble" "$link"; emit_plan; } > "${iss}.full"
+        if [ "$(wc -c < "${iss}.full")" -le "$max" ]; then
+          mv "${iss}.full" "$iss"
+        else
+          printf '%s\n\n%s\n' "$preamble" "$link" > "$iss"
+          rm -f "${iss}.full"
+        fi
+
+        echo "pr_path=$pr" >> "$GITHUB_OUTPUT"
+        echo "issue_relpath=$iss_rel" >> "$GITHUB_OUTPUT"
+
     # Posts (or updates) a single sticky PR comment linking to the full plan.
     # Replaces dflook's inline comment, which truncates large plans. Gated on
     # add_github_comment so consumers can still turn the PR comment off.
@@ -226,13 +260,9 @@ runs:
       with:
         github-token: ${{ github.token }}
         script: |
+          const fs = require('fs');
           const marker = '<!-- glueops-opentofu-plan -->';
-          const body = [
-            marker,
-            '## OpenTofu Plan',
-            '',
-            `⬇️ Download the full plan (one click, tofu-plan.txt): ${process.env.ARTIFACT_URL}`,
-          ].join('\n');
+          const body = fs.readFileSync(process.env.BODY_PATH, 'utf8');
           const { owner, repo } = context.repo;
           const issue_number = context.issue.number;
           try {
@@ -254,11 +284,11 @@ runs:
             // Don't fail the run just because we couldn't comment. Common causes:
             // a PR from a fork (GITHUB_TOKEN is read-only regardless of the
             // workflow's permissions), or a same-repo run missing 'pull-requests:
-            // write'. The plan is still on the job summary and the tofu-plan artifact.
-            core.warning(`Could not post the plan comment; the plan is still on the job summary and the tofu-plan artifact. Expected for fork PRs (read-only token); for same-repo PRs ensure the workflow grants 'pull-requests: write'. Error: ${e.message}`);
+            // write'. The plan is still on the tofu-plan artifact.
+            core.warning(`Could not post the plan comment; the plan is still on the tofu-plan artifact. Expected for fork PRs (read-only token); for same-repo PRs ensure the workflow grants 'pull-requests: write'. Error: ${e.message}`);
           }
       env:
-        ARTIFACT_URL: ${{ steps.upload_plan.outputs.artifact-url }}
+        BODY_PATH: ${{ steps.bodies.outputs.pr_path }}
 
     ## IMPORTANT
     ## DO NOT REMOVE THIS MANUAL APPROVAL STEP UNLESS YOU WANT AUTO APPLY WITHOUT ANY APPROVALS.
@@ -270,10 +300,11 @@ runs:
         approvers: ${{ github.actor }}
         minimum-approvals: 1
         issue-title: "Approve or Deny tofu apply"
-        issue-body: |
-          Approve or Deny tofu apply. Review the plan before approving:
-
-          ⬇️ Download the full plan (one click, tofu-plan.txt): ${{ steps.upload_plan.outputs.artifact-url }}
+        # Body is built by the "Build plan comment and approval issue bodies" step
+        # (link always, plus the inline plan when it fits). issue-body is the
+        # fallback used only when no text plan exists (issue-body-file-path empty).
+        issue-body: "Approve or Deny tofu apply."
+        issue-body-file-path: ${{ steps.bodies.outputs.issue_relpath }}
         exclude-workflow-initiator-as-approver: false
 
     - name: tofu apply

--- a/action.yml
+++ b/action.yml
@@ -173,7 +173,7 @@ runs:
     - name: Upload full plan as artifact
       id: upload_plan
       if: steps.plan.outputs.text_plan_path != ''
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: tofu-plan
         path: ${{ steps.plan.outputs.text_plan_path }}

--- a/action.yml
+++ b/action.yml
@@ -59,7 +59,9 @@ inputs:
   enable_slack_notification_for_approval:
     description: "DEPRECATED and ignored. Slack notifications have been removed entirely. This input is retained only to avoid breaking existing workflows that still set it."
     required: false
-    default: "true"
+    # Defaults to empty so the deprecation warning below only fires for consumers
+    # who still explicitly set this input, not on every run.
+    default: ""
   ENABLE_DANGEROUS_AUTO_APPLY_MODE:
     description: "If enabled, any changes including: Destroy, Apply, Replace will be automatically approved."
     required: false
@@ -159,12 +161,21 @@ runs:
     - name: Publish full plan to job summary
       if: steps.plan.outputs.text_plan_path != ''
       shell: bash
+      env:
+        # Pass via env (not inline ${{ }}) to avoid shell-injection from the value.
+        PLAN_PATH: ${{ steps.plan.outputs.text_plan_path }}
       run: |
+        # Choose a code fence longer than the longest run of backticks in the
+        # plan, so a plan line that itself contains ``` cannot close the block.
+        longest=$(grep -oE '`+' "$PLAN_PATH" | awk '{ if (length > m) m = length } END { print m+0 }' || true)
+        len=3
+        if [ "${longest:-0}" -ge 3 ]; then len=$((longest + 1)); fi
+        fence=$(printf '%*s' "$len" '' | tr ' ' '`')
         {
           echo '## OpenTofu Plan'
-          echo '```'
-          cat "${{ steps.plan.outputs.text_plan_path }}"
-          echo '```'
+          echo "$fence"
+          cat "$PLAN_PATH"
+          echo "$fence"
         } >> "$GITHUB_STEP_SUMMARY"
 
     # Always uploads the full plan as a downloadable artifact. Artifacts have no
@@ -197,17 +208,25 @@ runs:
           ].join('\n');
           const { owner, repo } = context.repo;
           const issue_number = context.issue.number;
-          // Scan pages and stop as soon as the marker is found, rather than
-          // eagerly fetching every comment (faster on large PRs).
-          let existing;
-          for await (const { data: page } of github.paginate.iterator(github.rest.issues.listComments, { owner, repo, issue_number, per_page: 100 })) {
-            existing = page.find(c => c.body && c.body.includes(marker));
-            if (existing) break;
-          }
-          if (existing) {
-            await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
-          } else {
-            await github.rest.issues.createComment({ owner, repo, issue_number, body });
+          try {
+            // Scan pages and stop as soon as the marker is found, rather than
+            // eagerly fetching every comment (faster on large PRs).
+            let existing;
+            for await (const { data: page } of github.paginate.iterator(github.rest.issues.listComments, { owner, repo, issue_number, per_page: 100 })) {
+              existing = page.find(c => c.body && c.body.includes(marker));
+              if (existing) break;
+            }
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number, body });
+            }
+          } catch (e) {
+            // Don't fail the run just because we couldn't comment. This is expected
+            // for PRs opened from forks, where GITHUB_TOKEN is read-only regardless
+            // of the workflow's permissions. The plan is still on the job summary
+            // and the tofu-plan artifact.
+            core.warning(`Could not post the plan comment (expected for fork PRs with a read-only token): ${e.message}`);
           }
       env:
         SUMMARY_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/action.yml
+++ b/action.yml
@@ -231,8 +231,8 @@ runs:
             marker,
             '## OpenTofu Plan',
             '',
-            `- Full plan (rendered in browser, run summary): ${process.env.SUMMARY_URL}`,
-            `- Full plan (downloadable artifact): ${process.env.ARTIFACT_URL}`,
+            `- 📄 View the plan in the run summary: ${process.env.SUMMARY_URL}`,
+            `- ⬇️ Download the full plan (one click, tofu-plan.txt): ${process.env.ARTIFACT_URL}`,
           ].join('\n');
           const { owner, repo } = context.repo;
           const issue_number = context.issue.number;
@@ -273,10 +273,10 @@ runs:
         minimum-approvals: 1
         issue-title: "Approve or Deny tofu apply"
         issue-body: |
-          Approve or Deny tofu apply.
+          Approve or Deny tofu apply. Review the plan before approving:
 
-          - Full plan (rendered in browser, run summary): ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          - Full plan (downloadable artifact): ${{ steps.upload_plan.outputs.artifact-url }}
+          - ⬇️ Download the full plan (one click, tofu-plan.txt): ${{ steps.upload_plan.outputs.artifact-url }}
+          - 📄 Plan in the run summary (renders after the job finishes): ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         exclude-workflow-initiator-as-approver: false
 
     - name: tofu apply

--- a/action.yml
+++ b/action.yml
@@ -55,7 +55,7 @@ inputs:
   add_github_comment:
     description: Post a sticky comment on the PR linking to the full plan (job summary / artifact)
     required: false
-    default: "true"
+    default: "false"
   enable_slack_notification_for_approval:
     description: "DEPRECATED and ignored. Slack notifications have been removed entirely. This input is retained only to avoid breaking existing workflows that still set it."
     required: false

--- a/action.yml
+++ b/action.yml
@@ -193,7 +193,7 @@ runs:
             marker,
             '## OpenTofu Plan',
             '',
-            `- Full plan (rendered in browser, job summary): ${process.env.SUMMARY_URL}`,
+            `- Full plan (rendered in browser, run summary): ${process.env.SUMMARY_URL}`,
             `- Full plan (downloadable artifact): ${process.env.ARTIFACT_URL}`,
           ].join('\n');
           const { owner, repo } = context.repo;
@@ -206,7 +206,7 @@ runs:
             await github.rest.issues.createComment({ owner, repo, issue_number, body });
           }
       env:
-        SUMMARY_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        SUMMARY_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         ARTIFACT_URL: ${{ steps.upload_plan.outputs.artifact-url }}
 
     ## IMPORTANT
@@ -222,7 +222,7 @@ runs:
         issue-body: |
           Approve or Deny tofu apply.
 
-          - Full plan (rendered in browser, job summary): https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          - Full plan (rendered in browser, run summary): ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           - Full plan (downloadable artifact): ${{ steps.upload_plan.outputs.artifact-url }}
         exclude-workflow-initiator-as-approver: false
 

--- a/action.yml
+++ b/action.yml
@@ -175,6 +175,9 @@ runs:
           echo '## OpenTofu Plan'
           echo "$fence"
           cat "$PLAN_PATH"
+          # Ensure the closing fence is on its own line even if the plan file
+          # has no trailing newline (otherwise the code block never closes).
+          printf '\n'
           echo "$fence"
         } >> "$GITHUB_STEP_SUMMARY"
 
@@ -213,7 +216,9 @@ runs:
             // eagerly fetching every comment (faster on large PRs).
             let existing;
             for await (const { data: page } of github.paginate.iterator(github.rest.issues.listComments, { owner, repo, issue_number, per_page: 100 })) {
-              existing = page.find(c => c.body && c.body.includes(marker));
+              // Require the bot to own the comment so a human-planted marker
+              // can't redirect our update onto their comment.
+              existing = page.find(c => c.body && c.body.includes(marker) && c.user && c.user.type === 'Bot');
               if (existing) break;
             }
             if (existing) {
@@ -222,11 +227,11 @@ runs:
               await github.rest.issues.createComment({ owner, repo, issue_number, body });
             }
           } catch (e) {
-            // Don't fail the run just because we couldn't comment. This is expected
-            // for PRs opened from forks, where GITHUB_TOKEN is read-only regardless
-            // of the workflow's permissions. The plan is still on the job summary
-            // and the tofu-plan artifact.
-            core.warning(`Could not post the plan comment (expected for fork PRs with a read-only token): ${e.message}`);
+            // Don't fail the run just because we couldn't comment. Common causes:
+            // a PR from a fork (GITHUB_TOKEN is read-only regardless of the
+            // workflow's permissions), or a same-repo run missing 'pull-requests:
+            // write'. The plan is still on the job summary and the tofu-plan artifact.
+            core.warning(`Could not post the plan comment; the plan is still on the job summary and the tofu-plan artifact. Expected for fork PRs (read-only token); for same-repo PRs ensure the workflow grants 'pull-requests: write'. Error: ${e.message}`);
           }
       env:
         SUMMARY_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/action.yml
+++ b/action.yml
@@ -55,7 +55,7 @@ inputs:
   add_github_comment:
     description: Post a sticky comment on the PR linking to the full plan (job summary / artifact)
     required: false
-    default: "false"
+    default: "true"
   enable_slack_notification_for_approval:
     description: "DEPRECATED and ignored. Slack notifications have been removed entirely. This input is retained only to avoid breaking existing workflows that still set it."
     required: false
@@ -149,10 +149,9 @@ runs:
         target: ${{ inputs.target }}
         replace: ${{ inputs.replace }}
         destroy: ${{ inputs.destroy }}
-        # We never use dflook's own comment. GitHub comments are capped at
-        # ~64 KB, so large plans truncate. Instead we publish the full plan to
-        # the job summary and an artifact and post our own links-only PR comment,
-        # consistent with the apply approval issue.
+        # Always disable dflook's own comment: GitHub comments are capped at
+        # ~64 KB, so large plans truncate. We post our own links-only PR comment
+        # below (gated on the add_github_comment input) instead.
         add_github_comment: "false"
 
     # Publishes the full, human-readable plan to the run's job summary page so it

--- a/action.yml
+++ b/action.yml
@@ -207,7 +207,7 @@ runs:
     # add_github_comment so consumers can still turn the PR comment off.
     - name: Comment plan links on PR
       if: github.event_name == 'pull_request' && inputs.add_github_comment == 'true' && steps.plan.outputs.text_plan_path != ''
-      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       with:
         github-token: ${{ github.token }}
         script: |

--- a/action.yml
+++ b/action.yml
@@ -53,7 +53,7 @@ inputs:
     description: The backend plugin name
     required: true
   add_github_comment:
-    description: Add the plan to a GitHub PR
+    description: Post a sticky comment on the PR linking to the full plan (job summary / artifact)
     required: false
     default: "true"
   enable_slack_notification_for_approval:
@@ -64,7 +64,7 @@ inputs:
     description: "If enabled, any changes including: Destroy, Apply, Replace will be automatically approved."
     required: false
     default: "false"
-    
+
 outputs:
   tofu:
     description: The tofu version used by the configuration
@@ -86,7 +86,7 @@ outputs:
     description: If the root module uses the `remote` or `cloud` backend in remote execution mode, this output will be set to the remote run id.
   failure-reason:
     description: The reason for the build failure. May be `apply-failed` or `plan-changed`.
-  
+
 
 runs:
   using: "composite"
@@ -133,7 +133,7 @@ runs:
         workspace: ${{ inputs.workspace }}
         backend_config: ${{ inputs.backend_config }}
         backend_config_file: ${{ inputs.backend_config_file }}
-  
+
     - name: tofu plan
       id: plan
       uses: dflook/tofu-plan@3f5dc358343fb58cd60f83b019e810315aa8258f # v2.2.3
@@ -149,13 +149,14 @@ runs:
         target: ${{ inputs.target }}
         replace: ${{ inputs.replace }}
         destroy: ${{ inputs.destroy }}
-        add_github_comment:  ${{ inputs.add_github_comment }}
+        # We never use dflook's own comment. GitHub comments are capped at
+        # ~64 KB, so large plans truncate. Instead we publish the full plan to
+        # the job summary and an artifact and post our own links-only PR comment,
+        # consistent with the apply approval issue.
+        add_github_comment: "false"
 
-    # Publishes the full, human-readable plan to the run's job summary page.
-    # GitHub PR/issue/commit comments are capped at 65,536 characters, so large
-    # plans get truncated in the PR comment and the approval issue. The job
-    # summary has a ~1 MiB limit and renders in the browser, so approvers can
-    # read the full plan without downloading anything or re-running the workflow.
+    # Publishes the full, human-readable plan to the run's job summary page so it
+    # can be read in the browser without downloading anything or re-running.
     - name: Publish full plan to job summary
       if: steps.plan.outputs.text_plan_path != ''
       shell: bash
@@ -167,9 +168,9 @@ runs:
           echo '```'
         } >> "$GITHUB_STEP_SUMMARY"
 
-    # Uploads the full text plan as a downloadable artifact. The job summary
-    # above covers the common case, but artifacts have no practical size limit
-    # and never truncate, so this is the fallback for very large plans (>1 MiB).
+    # Always uploads the full plan as a downloadable artifact. Artifacts have no
+    # practical size limit, so this guarantees the full plan is accessible even
+    # when it is too large for the job summary or a comment.
     - name: Upload full plan as artifact
       id: upload_plan
       if: steps.plan.outputs.text_plan_path != ''
@@ -177,6 +178,36 @@ runs:
       with:
         name: tofu-plan
         path: ${{ steps.plan.outputs.text_plan_path }}
+
+    # Posts (or updates) a single sticky PR comment linking to the full plan.
+    # Replaces dflook's inline comment, which truncates large plans. Gated on
+    # add_github_comment so consumers can still turn the PR comment off.
+    - name: Comment plan links on PR
+      if: github.event_name == 'pull_request' && inputs.add_github_comment == 'true' && steps.plan.outputs.text_plan_path != ''
+      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+      with:
+        github-token: ${{ github.token }}
+        script: |
+          const marker = '<!-- glueops-opentofu-plan -->';
+          const body = [
+            marker,
+            '## OpenTofu Plan',
+            '',
+            `- Full plan (rendered in browser, job summary): ${process.env.SUMMARY_URL}`,
+            `- Full plan (downloadable artifact): ${process.env.ARTIFACT_URL}`,
+          ].join('\n');
+          const { owner, repo } = context.repo;
+          const issue_number = context.issue.number;
+          const comments = await github.paginate(github.rest.issues.listComments, { owner, repo, issue_number });
+          const existing = comments.find(c => c.body && c.body.includes(marker));
+          if (existing) {
+            await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+          } else {
+            await github.rest.issues.createComment({ owner, repo, issue_number, body });
+          }
+      env:
+        SUMMARY_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        ARTIFACT_URL: ${{ steps.upload_plan.outputs.artifact-url }}
 
     ## IMPORTANT
     ## DO NOT REMOVE THIS MANUAL APPROVAL STEP UNLESS YOU WANT AUTO APPLY WITHOUT ANY APPROVALS.

--- a/action.yml
+++ b/action.yml
@@ -70,24 +70,34 @@ inputs:
 outputs:
   tofu:
     description: The tofu version used by the configuration
+    value: ${{ steps.Versions.outputs.tofu }}
   changes:
     description: If the generated plan would update any resources or outputs this is set to `true`, otherwise it's set to `false`.
+    value: ${{ steps.plan.outputs.changes }}
   to_add:
     description: The number of resources that would be added by this plan
+    value: ${{ steps.plan.outputs.to_add }}
   to_change:
     description: The number of resources that would be changed by this plan
+    value: ${{ steps.plan.outputs.to_change }}
   to_destroy:
     description: The number of resources that would be destroyed by this plan
+    value: ${{ steps.plan.outputs.to_destroy }}
   plan_path:
     description: Path to a file in the workspace containing the generated plan in an opaque binary format.
+    value: ${{ steps.plan.outputs.plan_path }}
   text_plan_path:
     description: Path to a file in the workspace containing the generated plan in human readable format. This won't be set if the backend type is `remote` and `auto_approve` is `true`
+    value: ${{ steps.plan.outputs.text_plan_path }}
   json_plan_path:
     description: Path to a file in the workspace containing the generated plan in JSON format. This won't be set if the backend type is `remote`.
+    value: ${{ steps.plan.outputs.json_plan_path }}
   run_id:
     description: If the root module uses the `remote` or `cloud` backend in remote execution mode, this output will be set to the remote run id.
+    value: ${{ steps.plan.outputs.run_id }}
   failure-reason:
     description: The reason for the build failure. May be `apply-failed` or `plan-changed`.
+    value: ${{ steps.plan.outputs.failure-reason || steps.apply.outputs.failure-reason }}
 
 
 runs:
@@ -255,6 +265,7 @@ runs:
         exclude-workflow-initiator-as-approver: false
 
     - name: tofu apply
+      id: apply
       if: github.ref_name == 'main' && steps.plan.outputs.changes == 'true'
       uses: dflook/tofu-apply@c254eb5b2e48978c05587373100d26b604c2182d # v2.2.3
       with:

--- a/action.yml
+++ b/action.yml
@@ -54,7 +54,7 @@ inputs:
     description: The backend plugin name
     required: true
   add_github_comment:
-    description: Post a sticky comment on the PR linking to the full plan (job summary / artifact)
+    description: Post a sticky comment on the PR with the plan (inlined when it fits, otherwise a link to the tofu-plan.txt artifact)
     required: false
     default: "true"
   enable_slack_notification_for_approval:
@@ -207,7 +207,7 @@ runs:
         # it with margin; byte count is a safe proxy (UTF-8 bytes >= characters).
         max=64000
         marker='<!-- glueops-opentofu-plan -->'
-        link="⬇️ Download the full plan (one click, tofu-plan.txt): ${ARTIFACT_URL}"
+        link="⬇️ Download the full plan (tofu-plan.txt): ${ARTIFACT_URL}"
 
         # Backtick-safe fence longer than the longest run of backticks in the plan.
         longest=$(grep -oE '`+' "$PLAN_PATH" | awk '{ if (length > m) m = length } END { print m+0 }' || true)
@@ -326,3 +326,11 @@ runs:
         target: ${{ inputs.target }}
         replace: ${{ inputs.replace }}
         destroy: ${{ inputs.destroy }}
+
+    # Remove the approval-issue body file from the checkout. It must live under
+    # the workspace so the manual-approval Docker action can read it, but it
+    # contains the full plan (possibly sensitive), so don't leave it behind.
+    - name: Clean up plan body file
+      if: always()
+      shell: bash
+      run: rm -f "${GITHUB_WORKSPACE}/.glueops_approval_issue.md"

--- a/action.yml
+++ b/action.yml
@@ -163,8 +163,9 @@ runs:
         replace: ${{ inputs.replace }}
         destroy: ${{ inputs.destroy }}
         # Always disable dflook's own comment: GitHub comments are capped at
-        # ~64 KB, so large plans truncate. We post our own links-only PR comment
-        # below (gated on the add_github_comment input) instead.
+        # ~64 KB, so large plans truncate. We post our own PR comment below
+        # (plan inlined when it fits, else a download link), gated on the
+        # add_github_comment input.
         add_github_comment: "false"
 
     # Copy the plan to a clean, predictable filename. With archive: false the
@@ -181,9 +182,9 @@ runs:
         cp "$PLAN_PATH" "$dest"
         echo "path=$dest" >> "$GITHUB_OUTPUT"
 
-    # Always uploads the full plan as a single uncompressed file (archive: false),
-    # so it downloads as tofu-plan.txt directly with no zip to extract. Artifacts
-    # have no practical size limit, guaranteeing the full plan is always accessible.
+    # Uploads the full plan as a single uncompressed file (archive: false)
+    # whenever a text plan was produced, so it downloads as tofu-plan.txt with no
+    # zip to extract. Artifacts have no practical size limit.
     - name: Upload full plan as artifact
       id: upload_plan
       if: steps.plan.outputs.text_plan_path != ''
@@ -287,8 +288,8 @@ runs:
             // Don't fail the run just because we couldn't comment. Common causes:
             // a PR from a fork (GITHUB_TOKEN is read-only regardless of the
             // workflow's permissions), or a same-repo run missing 'pull-requests:
-            // write'. The plan is still on the tofu-plan artifact.
-            core.warning(`Could not post the plan comment; the plan is still on the tofu-plan artifact. Expected for fork PRs (read-only token); for same-repo PRs ensure the workflow grants 'pull-requests: write'. Error: ${e.message}`);
+            // write'. The plan is still on the tofu-plan.txt artifact.
+            core.warning(`Could not post the plan comment; the plan is still on the tofu-plan.txt artifact. Expected for fork PRs (read-only token); for same-repo PRs ensure the workflow grants 'pull-requests: write'. Error: ${e.message}`);
           }
       env:
         BODY_PATH: ${{ steps.bodies.outputs.pr_path }}
@@ -299,7 +300,7 @@ runs:
       if: github.ref_name == 'main' && steps.plan.outputs.changes == 'true' && inputs.ENABLE_DANGEROUS_AUTO_APPLY_MODE == 'false'
       uses: trstringer/manual-approval@74d99dff7380e3e4b122d4ededcbca2b6ce59367 # v1
       with:
-        secret: ${{ github.TOKEN }}
+        secret: ${{ github.token }}
         approvers: ${{ github.actor }}
         minimum-approvals: 1
         issue-title: "Approve or Deny tofu apply"

--- a/action.yml
+++ b/action.yml
@@ -192,16 +192,30 @@ runs:
           echo "$fence"
         } >> "$GITHUB_STEP_SUMMARY"
 
-    # Always uploads the full plan as a downloadable artifact. Artifacts have no
-    # practical size limit, so this guarantees the full plan is accessible even
-    # when it is too large for the job summary or a comment.
+    # Copy the plan to a clean, predictable filename. With archive: false the
+    # uploaded file's name becomes the artifact name (the name: input is ignored),
+    # so we set it here. Path is passed via env to avoid shell injection.
+    - name: Stage plan file for artifact
+      id: stage_plan
+      if: steps.plan.outputs.text_plan_path != ''
+      shell: bash
+      env:
+        PLAN_PATH: ${{ steps.plan.outputs.text_plan_path }}
+      run: |
+        dest="${RUNNER_TEMP}/tofu-plan.txt"
+        cp "$PLAN_PATH" "$dest"
+        echo "path=$dest" >> "$GITHUB_OUTPUT"
+
+    # Always uploads the full plan as a single uncompressed file (archive: false),
+    # so it downloads as tofu-plan.txt directly with no zip to extract. Artifacts
+    # have no practical size limit, guaranteeing the full plan is always accessible.
     - name: Upload full plan as artifact
       id: upload_plan
       if: steps.plan.outputs.text_plan_path != ''
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
-        name: tofu-plan
-        path: ${{ steps.plan.outputs.text_plan_path }}
+        path: ${{ steps.stage_plan.outputs.path }}
+        archive: false
 
     # Posts (or updates) a single sticky PR comment linking to the full plan.
     # Replaces dflook's inline comment, which truncates large plans. Gated on

--- a/test/main.tf
+++ b/test/main.tf
@@ -4,6 +4,15 @@ terraform {
   # Local backend keeps state on the runner only — throwaway, no credentials,
   # so the integration test is fully isolated per run.
   backend "local" {}
+
+  # Pin the provider so the fixture is deterministic and a new major release
+  # can't change its behavior unexpectedly.
+  required_providers {
+    null = {
+      source  = "hashicorp/null"
+      version = "~> 3.2"
+    }
+  }
 }
 
 # A no-op resource (no cloud provider / credentials needed). Because the local

--- a/test/main.tf
+++ b/test/main.tf
@@ -1,0 +1,15 @@
+terraform {
+  required_version = ">= 1.6.0"
+
+  # Local backend keeps state on the runner only — throwaway, no credentials,
+  # so the integration test is fully isolated per run.
+  backend "local" {}
+}
+
+# A no-op resource (no cloud provider / credentials needed). Because the local
+# state never persists across runs, every run plans "1 to add".
+resource "null_resource" "integration_test" {}
+
+output "ok" {
+  value = "integration-test"
+}


### PR DESCRIPTION
Follow-up to #128. Makes the plan easy to access (incl. large plans) from the PR and the apply-approval flow, removes Slack, and adds an isolated integration test. This PR evolved substantially through review; summary reflects the final state.

## Plan visibility
- The full plan is **always** uploaded as an artifact named `tofu-plan.txt`, uploaded uncompressed (`actions/upload-artifact` **v7.0.1**, `archive: false`) so it downloads as a single file with no zip to extract.
- On PRs, a single **sticky comment** (`actions/github-script` **v9.0.0**) always links to the artifact and **inlines the full plan** (collapsible) when the whole comment fits under GitHub's 65,536-char limit; otherwise link-only (never a partial plan). Gated by `add_github_comment` (default `true`). dflook's own comment is disabled.
- On `main` apply, `manual-approval` posts the same content as a **comment on the approval issue** (via `issue-body-file-path`).
- The job-summary surface was removed entirely.

## Slack
- Removed all Slack steps. `enable_slack_notification_for_approval` kept as a deprecated no-op input (default `""`); a warning fires only if it's still set.

## Other
- Composite action **outputs are now wired** with `value:` mappings (were silently empty before).
- All actions pinned to SHAs.
- **Integration test** (`.github/workflows/integration-test.yml`) runs on every PR commit + push-to-main against a throwaway local-backend `null_resource` fixture; asserts plan outputs, the inline comment (link + `<details>` + content), and the downloaded artifact. Apply auto-runs on main. Reviewed across four adversarial review rounds.

## Notes
- Not a breaking change; `add_github_comment` keeps the same name/default.
- The `manual-approval` `issue-body-file-path` path isn't CI-covered (auto-apply skips the gate); verified by review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)