### PR TITLE
feat: vendor manual-approval action pinned to image digest (1/2)

### DIFF
--- a/vendored/manual-approval/action.yaml
+++ b/vendored/manual-approval/action.yaml
@@ -1,0 +1,81 @@
+# Vendored copy of trstringer/manual-approval's action.yaml.
+#
+# Source:  https://github.com/trstringer/manual-approval (tag v1.12.0,
+#          commit 74d99dff7380e3e4b122d4ededcbca2b6ce59367)
+# Why:     The upstream action.yaml references the Docker image by the MUTABLE
+#          tag ":1.12.0". This copy is byte-for-byte identical EXCEPT the image
+#          is pinned to an immutable SHA-256 digest (see the runs.image line).
+#          This closes the supply-chain gap in
+#          https://github.com/trstringer/manual-approval/issues/214 without
+#          forking the Go codebase — we still run trstringer's published image.
+#
+# To update: re-verify the digest with
+#   docker buildx imagetools inspect ghcr.io/trstringer/manual-approval:<ver>
+# then bump both the version reference above and the digest below.
+name: Manual Workflow Approval
+description: Pause a workflow and get user approval to continue
+branding:
+  icon: pause
+  color: yellow
+inputs:
+  approvers:
+    description: Required approvers
+    required: true
+  secret:
+    description: Secret
+    required: true
+  minimum-approvals:
+    description: Minimum number of approvals to progress workflow
+    required: false
+  issue-title:
+    description: The custom subtitle for the issue
+    required: false
+  issue-body:
+    description: The custom body for the issue
+    required: false
+  issue-body-file-path:
+    description: The file path to a custom body for the issue
+    required: false
+  exclude-workflow-initiator-as-approver:
+    description: Whether or not to filter out the user who initiated the workflow as an approver if they are in the approvers list
+    required: false
+    default: 'false'
+  additional-approved-words:
+    description: Comma separated list of words that can be used to approve beyond the defaults.
+    required: false
+    default: ''
+  additional-denied-words:
+    description: Comma separated list of words that can be used to deny beyond the defaults.
+    required: false
+    default: ''
+  target-repository-owner:
+    description: Owner of the repository in which the issue will be created.
+    default: ''
+  target-repository:
+    description: Name of the repository in which the issue will be created.
+    default: ''
+  fail-on-denial:
+    description: Whether or not to fail the workflow if the approval is denied
+    required: false
+    default: 'true'
+  polling-interval-seconds:
+    description: Number of seconds to wait between polling GitHub API for approval status
+    required: false
+    default: '10'
+  close-issue-means-denial:
+    description: >
+      If true, closing the approval issue without an explicit approval
+      comment will be treated as a denial. Disabled by default.
+    required: false
+    default: "false"
+outputs:
+  issue-number:
+    description: The number of the issue created
+  issue-url:
+    description: The URL of the issue created
+  approval-status:
+    description: The status of the approval ("approved" or "denied")
+runs:
+  using: docker
+  # Pinned by digest (was: docker://ghcr.io/trstringer/manual-approval:1.12.0)
+  image: docker://ghcr.io/trstringer/manual-approval@sha256:59bd4cd8be925c77642bb6a2f32c359ab5568e74d5b47edb3eec26b750d4873c


### PR DESCRIPTION
## What

Adds `vendored/manual-approval/action.yaml` — a verbatim copy of [`trstringer/manual-approval`](https://github.com/trstringer/manual-approval)'s `action.yaml` (tag `v1.12.0`, commit `74d99dff7380e3e4b122d4ededcbca2b6ce59367`), changing **only** the `runs.image` reference:

- **From** (mutable tag): `docker://ghcr.io/trstringer/manual-approval:1.12.0`
- **To** (immutable digest): `docker://ghcr.io/trstringer/manual-approval@sha256:59bd4cd8be925c77642bb6a2f32c359ab5568e74d5b47edb3eec26b750d4873c`

## Why

The `Approve or Deny tofu apply` step is already pinned to the upstream commit SHA, which locks the *git* layer. But the upstream `action.yaml` still pulls its Docker image by a **mutable tag**, leaving the image layer open to a repush — the supply-chain gap tracked in [trstringer/manual-approval#214](https://github.com/trstringer/manual-approval/issues/214).

We can't edit upstream's `action.yaml` without forking the Go codebase, and a local `./` reference doesn't resolve from inside a composite action ([actions/runner#1348](https://github.com/actions/runner/issues/1348)). Vendoring just the one file and referencing it by full repo path keeps our `with:` inputs identical while pinning the image by digest. We still run trstringer's published image — only the reference is hardened.

## Scope of this PR (1 of 2)

This PR **only adds the vendored file** so `main` stays working. A follow-up PR will repoint the step at this file via its commit SHA:

```yaml
uses: GlueOps/github-actions-opentofu-continuous-delivery/vendored/manual-approval@<this-PR's-merge-commit-SHA>
```

## Note for reviewers

The digest was captured today via `docker buildx imagetools inspect ghcr.io/trstringer/manual-approval:1.12.0` (the multi-arch manifest digest). Worth a re-verify before merge, since image digests change on any rebuild.