### PR TITLE
feat: repoint manual-approval step to digest-pinned vendored action (2/2)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -298,7 +298,12 @@ runs:
     ## DO NOT REMOVE THIS MANUAL APPROVAL STEP UNLESS YOU WANT AUTO APPLY WITHOUT ANY APPROVALS.
     - name: Approve or Deny tofu apply
       if: github.ref_name == 'main' && steps.plan.outputs.changes == 'true' && inputs.ENABLE_DANGEROUS_AUTO_APPLY_MODE == 'false'
-      uses: trstringer/manual-approval@74d99dff7380e3e4b122d4ededcbca2b6ce59367 # v1
+      # Vendored copy of trstringer/manual-approval (v1.12.0) with the Docker
+      # image pinned to an immutable digest — see vendored/manual-approval/action.yaml.
+      # Referenced by full repo path: a local "./" ref does NOT resolve from
+      # inside a composite action (actions/runner#1348). The @ref is the commit
+      # that contains the vendored file; bump it when the vendored file changes.
+      uses: GlueOps/github-actions-opentofu-continuous-delivery/vendored/manual-approval@f77db6210b99a916ea1c16aa14722a3e96fe20e4 # trstringer/manual-approval v1.12.0, digest-pinned
       with:
         secret: ${{ github.token }}
         approvers: ${{ github.actor }}


### PR DESCRIPTION
## What

Repoints the `Approve or Deny tofu apply` step from the upstream action to the vendored copy added in #137:

```diff
- uses: trstringer/manual-approval@74d99dff7380e3e4b122d4ededcbca2b6ce59367 # v1
+ uses: GlueOps/github-actions-opentofu-continuous-delivery/vendored/manual-approval@f77db6210b99a916ea1c16aa14722a3e96fe20e4 # trstringer/manual-approval v1.12.0, digest-pinned
```

The step's `with:` inputs are **unchanged**.

## Why

This is part 2 of 2. #137 added `vendored/manual-approval/action.yaml` — a verbatim copy of trstringer's `action.yaml` (v1.12.0) with the Docker image pinned to an immutable digest (`sha256:59bd4cd8…`) instead of the mutable `:1.12.0` tag. This PR flips the step to actually use it, closing the image-layer supply-chain gap from [trstringer/manual-approval#214](https://github.com/trstringer/manual-approval/issues/214).

The `@ref` is the `main` commit that contains the vendored file (`f77db6210b99a916ea1c16aa14722a3e96fe20e4`, the squash-merge of #137). It's referenced by full repo path because a local `./` ref does not resolve from inside a composite action ([actions/runner#1348](https://github.com/actions/runner/issues/1348)).

## After this merges

Both layers are now immutable: the git layer (this repo, pinned by SHA when consumers reference us) and the image layer (digest in the vendored file). To bump manual-approval in future: re-verify the new digest, update `vendored/manual-approval/action.yaml`, then bump this `@ref` to the commit that contains the change.