### PR TITLE
feat: refresh stale versions in README usage examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Example:
 ```yaml
 env:
   TERRAFORM_ACTIONS_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  OPENTOFU_VERSION: "1.6.2"
+  OPENTOFU_VERSION: "1.8.5"
   # more provider environment variables can be set here
 
 
@@ -43,7 +43,7 @@ jobs:
       cancel-in-progress: false
     steps:
       - name: OpenTofu CD              
-        uses: GlueOps/github-actions-opentofu-continuous-delivery@v0.0.9
+        uses: GlueOps/github-actions-opentofu-continuous-delivery@v5.0.0
         with:
           backend_config: |
             access_key=${{ vars.TF_S3_BACKEND_AWS_ACCESS_KEY }}
@@ -137,14 +137,14 @@ Add the following secrets to your GitHub repository under `Settings > Secrets an
 Set the following environment variables in your workflow:
 
 - `TERRAFORM_ACTIONS_GITHUB_TOKEN`: Typically set to `${{ secrets.GITHUB_TOKEN }}`.
-- `OPENTOFU_VERSION`: Version of OpenTofu to use (e.g., `1.6.2`).
+- `OPENTOFU_VERSION`: Version of OpenTofu to use (e.g., `1.8.5`).
 
 Example:
 
 ```yaml
 env:
   TERRAFORM_ACTIONS_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  OPENTOFU_VERSION: "1.6.2"
+  OPENTOFU_VERSION: "1.8.5"
   # Additional environment variables can be added here
 ```
 


### PR DESCRIPTION
## What

Refreshes outdated values in the README usage examples so the docs match reality:

- `uses: GlueOps/github-actions-opentofu-continuous-delivery@v0.0.9` → `@v5.0.0` (current latest release)
- `OPENTOFU_VERSION: "1.6.2"` → `"1.8.5"` (the version `integration-test.yml` actually runs), in both code blocks and the inline example

## Why `feat:` and not `docs:`

Intentional: a `docs:` commit would **not** trigger a release-please release. Typing this as `feat:` so release-please opens a release PR and cuts a new version including this refresh (this also serves as the first end-to-end exercise of the release-please setup from #139).

## After merge

release-please should open a release PR proposing `v5.1.0` (minor, from the `feat:`). Merging that PR cuts the release + tag and creates `CHANGELOG.md`.