### PR TITLE
feat!: remove Slack notification surface entirely

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,6 @@ Beyond `contents: read` for checkout, the `tofu-plan.txt` artifact needs no `GIT
 | `destroy` | Create and apply a plan to destroy all resources | ❌ | `false` |
 | `backend_type` | The backend plugin name | ✅ | _None_ |
 | `add_github_comment` | Post a sticky PR comment with the plan (inlined when it fits, otherwise a link to the `tofu-plan.txt` artifact). | ❌ | `true` |
-| `enable_slack_notification_for_approval` | **Deprecated and ignored.** Slack notifications have been removed; retained only for backward compatibility. | ❌ | `""` |
 | `ENABLE_DANGEROUS_AUTO_APPLY_MODE` | If enabled, any changes including Destroy, Apply, and Replace will be automatically approved (skips the manual approval step). | ❌ | `false` |
 
 ## Outputs

--- a/action.yml
+++ b/action.yml
@@ -57,12 +57,6 @@ inputs:
     description: Post a sticky comment on the PR with the plan (inlined when it fits, otherwise a link to the tofu-plan.txt artifact)
     required: false
     default: "true"
-  enable_slack_notification_for_approval:
-    description: "DEPRECATED and ignored. Slack notifications have been removed entirely. This input is retained only to avoid breaking existing workflows that still set it."
-    required: false
-    # Defaults to empty so the deprecation warning below only fires for consumers
-    # who still explicitly set this input, not on every run.
-    default: ""
   ENABLE_DANGEROUS_AUTO_APPLY_MODE:
     description: "If enabled, any changes including: Destroy, Apply, Replace will be automatically approved."
     required: false
@@ -106,14 +100,6 @@ runs:
   steps:
     - name: Checkout
       uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-
-    # Slack notifications were removed entirely. The `enable_slack_notification_for_approval`
-    # input is kept as a no-op so existing workflows that still set it don't break.
-    - name: Slack notifications removed (deprecation notice)
-      if: inputs.enable_slack_notification_for_approval != ''
-      shell: bash
-      run: |
-        echo "::warning title=Slack notifications removed::Slack notifications have been removed from this action. The 'enable_slack_notification_for_approval' input is now ignored and retained only for backward compatibility. Please remove it from your workflow."
 
     - name: tofu fmt
       uses: dflook/tofu-fmt-check@1ae8a83029b8ad8e6c6a12834e0d3d9cd0e34d5f # v2.2.3


### PR DESCRIPTION
## What

Removes the last remnants of Slack support — which was already deprecated and a no-op:

- `enable_slack_notification_for_approval` **input definition** (`action.yml`)
- the **deprecation-notice step** that emitted a warning when the input was set (`action.yml`)
- the input's **row in the README** inputs table

After this, there are zero `slack` references in the repo (verified with `grep -rni slack`).

## Breaking change

Flagged as **breaking** (`feat!:` + `BREAKING CHANGE:` footer) because a documented input is removed from the action's public API → release-please will cut a **major** version (v6.0.0).

In practice the runtime impact is minimal: the input was already ignored, and GitHub silently ignores undeclared `with:` inputs, so existing workflows that still set `enable_slack_notification_for_approval` will continue to run (just without the deprecation warning). The major bump signals the API surface change to consumers.

## Release

On merge, release-please will open/refresh a release PR proposing **v6.0.0**.