### PR TITLE
ci: skip integration test on release-please PRs

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -11,6 +11,14 @@ name: Integration Test
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+    # Skip CI on release-please's release PR. It only edits CHANGELOG.md and
+    # .release-please-manifest.json (no action code), and it's authored by
+    # github-actions[bot], which the org's outside-contributor approval policy
+    # gates behind a manual "Approve and run". A path filter means no run is
+    # created for a PR touching only these files, so there's nothing to approve.
+    paths-ignore:
+      - 'CHANGELOG.md'
+      - '.release-please-manifest.json'
   push:
     branches: [main]
 


### PR DESCRIPTION
## What

Adds `paths-ignore` to the Integration Test `pull_request` trigger so it doesn't run on release-please's release PR:

```yaml
on:
  pull_request:
    types: [opened, synchronize, reopened]
    paths-ignore:
      - 'CHANGELOG.md'
      - '.release-please-manifest.json'
  push:
    branches: [main]
```

## Why

release-please's release PR (e.g. #143) is authored by `github-actions[bot]` and only ever edits `CHANGELOG.md` and `.release-please-manifest.json`. Because the repo/org's "outside contributor" Actions policy gates bot-authored PRs behind a manual **Approve and run**, every release PR has been requiring a manual click to run CI.

Path filters are evaluated **before** the run is created, so a PR that touches only these two files produces **no run** — and there's nothing to approve. (A job-level `if:` wouldn't help: the run would still be created in `action_required` first.)

## Impact

- ✅ No more manual approvals for release PRs.
- ✅ Real PRs (changing `action.yml`, tests, README, etc.) still trigger CI normally.
- ⚠️ The release PR itself gets no CI — acceptable, since it contains only auto-generated changelog/version content, not action code.
- A human PR that happens to touch *only* `CHANGELOG.md` would also skip CI, which is fine.

## Note

This is the lightweight fix. The alternative (a GitHub App token for release-please) also removes the gate and additionally lets release events trigger downstream workflows — worth revisiting if release automation gets standardized across GlueOps repos, but it needs org-owner setup and isn't needed for this repo today.