### PR TITLE
ci: auto-bump README version pin via release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,6 +16,7 @@ concurrency:
 permissions:
   contents: write
   pull-requests: write
+  issues: write
 
 jobs:
   release-please:

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ jobs:
       cancel-in-progress: false
     steps:
       - name: OpenTofu CD              
-        uses: GlueOps/github-actions-opentofu-continuous-delivery@v5.0.0
+        uses: GlueOps/github-actions-opentofu-continuous-delivery@v6.0.0 # x-release-please-version
         with:
           backend_config: |
             access_key=${{ vars.TF_S3_BACKEND_AWS_ACCESS_KEY }}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,7 +4,10 @@
     ".": {
       "release-type": "simple",
       "include-component-in-tag": false,
-      "changelog-path": "CHANGELOG.md"
+      "changelog-path": "CHANGELOG.md",
+      "extra-files": [
+        { "type": "generic", "path": "README.md" }
+      ]
     }
   }
 }


### PR DESCRIPTION
## What

Makes release-please keep the README usage example pinned to the current **exact** version automatically, instead of bumping it by hand.

- **`release-please-config.json`** — add an `extra-files` generic updater for `README.md`:
  ```json
  "extra-files": [
    { "type": "generic", "path": "README.md" }
  ]
  ```
- **`README.md`** — pin to `@v6.0.0` (current latest) and add the marker:
  ```yaml
  uses: GlueOps/github-actions-opentofu-continuous-delivery@v6.0.0 # x-release-please-version
  ```
- **`release-please.yml`** — add `issues: write` (release-please uses it for label management; prevents intermittent labeling failures).

## Effect

From the next release on, the release PR rewrites the README pin in-band (e.g. `@v6.0.0` → `@v6.1.0`) alongside the changelog/manifest. No more manual `feat:` version-bump commits, and consumers always copy a current exact pin.

**Deliberately no floating major tag** — exact pins match this repo's supply-chain posture (the alternative considered, a moving `@v6`, was rejected for that reason).

## Verify on first release

The generic updater matches the `6.0.0` semver portion and preserves the `@v` prefix. Worth eyeballing the **first** release PR after this merges to confirm it produces `@v6.1.0` (correct) and not a dropped `v` or wrong component.

## Note

This is `ci:` (release tooling), so it won't itself cut a release — it takes effect on the next `feat:`/`fix:` release PR.